### PR TITLE
upgrade pytorch-ie to 0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 # --------- pytorch-ie --------- #
 pytorch-ie>=0.7.0,<0.8
 
+# --------- pytorch --------- #
+torchvision>=0.11.0
+
 # --------- hydra --------- #
 hydra-core>=1.1.0
 hydra-colorlog>=1.1.0


### PR DESCRIPTION
… to use the latest version of datasets (see https://github.com/ChristophAlt/pytorch-ie/pull/185). This also removes torch, and pytorch-lightning from requirements because they are already required by pytorch-ie.