### PR TITLE
Fix screenshot(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ When running `python train.py` you should see something like this:
 ![](https://github.com/ChristophAlt/pytorch-ie-hydra-template/blob/resources/images/terminal1.png)
 ![](https://github.com/ChristophAlt/pytorch-ie-hydra-template/blob/resources/images/terminal2.png)
 ![](https://github.com/ChristophAlt/pytorch-ie-hydra-template/blob/resources/images/terminal3.png)
+![](https://github.com/ChristophAlt/pytorch-ie-hydra-template/blob/resources/images/terminal4.png)
 
 </div>
 


### PR DESCRIPTION
[preview](https://github.com/ChristophAlt/pytorch-ie-hydra-template/tree/fix_screenshot#quickstart)

As in [the original template](https://github.com/ashleve/lightning-hydra-template), the actual images are located in the `resources` branch.

Note: There is still an annoying warning at the beginning. However, this should be fixed in a separate PR.