### PR TITLE
improve hyperparameter logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # --------- pytorch-ie --------- #
 pytorch-ie>=0.28.0,<0.30.0
 pie-datasets>=0.8.1,<0.9.0
-pie-modules>=0.8.0,<0.9.0
+pie-modules>=0.9.0,<0.10.0
 
 # --------- hydra --------- #
 hydra-core>=1.3.0

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -107,7 +107,7 @@ def evaluate(cfg: DictConfig) -> Tuple[dict, dict]:
 
     if logger:
         log.info("Logging hyperparameters!")
-        utils.log_hyperparameters(object_dict)
+        utils.log_hyperparameters(logger=logger, model=model, taskmodule=taskmodule, config=cfg)
 
     log.info("Starting testing!")
     trainer.test(model=model, datamodule=datamodule, ckpt_path=cfg.ckpt_path)


### PR DESCRIPTION
This PR improves the hyperparameter logging when executing `train.py` or `evaluate.py` in the following ways, i.e. `log_hyperparameters()`:
 - the hydra-run config gets resolved before logging it, that means `ConfigDict` entries are correctly un-nested (compare the `dataset` entry in the W&B run config view, for instance)
 - remove duplicated entries by not logging `model._config()` and `taskmodule._config()` at all, because the model parameters are automatically logged by calling `self.save_hyperparameters()` in the model and in the future each model should receive `taskmodule_config` as parameter, so that will get logged as well (`taskmodule._config()` is currently still logged in some cases for backwards compatibility)
 - the method allows for arbitrary keyword arguments that will get logged
 - the logging keys for the config, number of model parameter, and all other parameters to log are prefixed with `key_prefix`, which is `"_"` per default, to distinguish them from the model parameters.

In addition, with this PR two more parameters are logged:
 - `_best_checkpoint`: `os.path.basename(best_ckpt_path)` taken from the checkpoint callback
 - `_checkpoint_dir`: `dirpath` taken from the checkpoint callback

**Note: this requires `pie-modules>=0.9.0`**