### PR TITLE
add brat serializer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # --------- pytorch-ie --------- #
 pytorch-ie>=0.28.0,<0.30.0
 pie-datasets>=0.8.1,<0.9.0
-git+https://github.com/ArneBinder/pie-modules.git
+pie-modules>=0.10.6,<0.11.0
 
 # --------- hydra --------- #
 hydra-core>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # --------- pytorch-ie --------- #
 pytorch-ie>=0.28.0,<0.30.0
 pie-datasets>=0.8.1,<0.9.0
-pie-modules>=0.9.0,<=0.10.5
+git+https://github.com/ArneBinder/pie-modules.git
 
 # --------- hydra --------- #
 hydra-core>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # --------- pytorch-ie --------- #
 pytorch-ie>=0.28.0,<0.30.0
 pie-datasets>=0.8.1,<0.9.0
-pie-modules>=0.9.0,<0.10.0
+pie-modules>=0.9.0,<=0.10.5
 
 # --------- hydra --------- #
 hydra-core>=1.3.0

--- a/src/serializer/__init__.py
+++ b/src/serializer/__init__.py
@@ -1,1 +1,2 @@
+from .brat import BratSerializer
 from .json import JsonSerializer

--- a/src/serializer/brat.py
+++ b/src/serializer/brat.py
@@ -173,7 +173,8 @@ def serialize_annotation_layers(
             annotations=layer.predictions,
             label_prefix=prediction_label_prefix,
             first_idx=len(serialized_annotations),
-            # predicted annotations can reference both gold and predicted annotations
+            # Predicted annotations can reference both gold and predicted annotations.
+            # Note that predictions take precedence over gold annotations.
             annotation2id={**gold_annotation2id, **prediction_annotation2id},
         )
         prediction_annotation2id.update(new_pred_ann2id)

--- a/src/serializer/brat.py
+++ b/src/serializer/brat.py
@@ -1,7 +1,7 @@
 import json
 import os
 from collections import defaultdict
-from typing import DefaultDict, Dict, List, Optional, Sequence, Tuple, TypeVar
+from typing import DefaultDict, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
 
 from pie_datasets.core.dataset_dict import METADATA_FILE_NAME
 from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
@@ -19,8 +19,50 @@ log = get_pylogger(__name__)
 D = TypeVar("D", bound=Document)
 
 
+def serialize_labeled_span(
+    span_id: str,
+    labeled_span: Union[LabeledMultiSpan, LabeledSpan],
+    label_prefix: Optional[str] = None,
+) -> str:
+    """Serialize a labeled span into a string representation.
+
+    Args:
+        span_id (str): The identifier for the labeled span.
+        labeled_span (Union[LabeledMultiSpan, LabeledSpan]): The labeled span object to serialize.
+            It can be either a LabeledMultiSpan or a LabeledSpan.
+        label_prefix (Optional[str], optional): A prefix to be added to the label.
+            Defaults to None.
+
+    Returns:
+        str: The serialized representation of the labeled_span.
+
+    Raises:
+        Warning: If the labeled_span has an unknown type.
+    """
+    label = labeled_span.label if label_prefix is None else f"{label_prefix}-{labeled_span.label}"
+    if isinstance(labeled_span, LabeledMultiSpan):
+        locations = []
+        texts = []
+        for slice in labeled_span.slices:
+            start_idx = slice[0]
+            end_idx = slice[1]
+            texts.append(labeled_span.target[start_idx:end_idx])
+            locations.append(f"{start_idx} {end_idx}")
+        location = ";".join(locations)
+        text = " ".join(texts)
+        serialized_labeled_span = f"{span_id}\t{label} {location}\t{text}\n"
+    elif isinstance(labeled_span, LabeledSpan):
+        start_idx = labeled_span.start
+        end_idx = labeled_span.end
+        entity_text = labeled_span.target[start_idx:end_idx]
+        serialized_labeled_span = f"{span_id}\t{label} {start_idx} {end_idx}\t{entity_text}\n"
+    else:
+        raise Warning(f"labeled span has unknown type: {type(labeled_span)}")
+    return serialized_labeled_span
+
+
 def serialize_labeled_spans(
-    entities: BaseAnnotationList,
+    labeled_spans: BaseAnnotationList,
     label_prefix: Optional[str] = None,
     first_span_id: int = 0,
 ) -> Tuple[List[str], Dict[LabeledSpan, str]]:
@@ -28,7 +70,7 @@ def serialize_labeled_spans(
     Brat format.
 
     Parameters:
-        entities (BaseAnnotationList): The list of entity annotations.
+        labeled_spans (BaseAnnotationList): The list of entity annotations.
         label_prefix (Optional[str]): An optional prefix to add to entity labels.
         first_span_id: An integer value used for creating span annotation IDs. It ensures the proper assignment of IDs
             for predicted annotations, particularly when gold annotations have already been included.
@@ -38,35 +80,55 @@ def serialize_labeled_spans(
         entity annotations in the Brat format, and a dictionary mapping labeled spans to their IDs.
     """
     span2id: Dict[LabeledSpan, str] = defaultdict()
-    ann_entities = []
-    for i, entity in enumerate(entities, start=first_span_id):
-        entity_id = f"T{i}"
-        label = entity.label if label_prefix is None else f"{label_prefix}-{entity.label}"
-        if isinstance(entity, LabeledMultiSpan):
-            locations = []
-            texts = []
-            for slice in entity.slices:
-                start_idx = slice[0]
-                end_idx = slice[1]
-                texts.append(entity.target[start_idx:end_idx])
-                locations.append(f"{start_idx} {end_idx}")
-            location = ";".join(locations)
-            text = " ".join(texts)
-            entry = f"{entity_id}\t{label} {location}\t{text}\n"
-        elif isinstance(entity, LabeledSpan):
-            start_idx = entity.start
-            end_idx = entity.end
-            entity_text = entity.target[start_idx:end_idx]
-            entry = f"{entity_id}\t{label} {start_idx} {end_idx}\t{entity_text}\n"
-        else:
-            raise Warning(f"labeled span has unknown type: {type(entity)}")
-        span2id[entity] = entity_id
-        ann_entities.append(entry)
-    return ann_entities, span2id
+    serialized_labeled_spans = []
+    for i, labeled_span in enumerate(labeled_spans, start=first_span_id):
+        span_id = f"T{i}"
+        serialized_labeled_span = serialize_labeled_span(
+            span_id=span_id, labeled_span=labeled_span, label_prefix=label_prefix
+        )
+        span2id[labeled_span] = span_id
+        serialized_labeled_spans.append(serialized_labeled_span)
+    return serialized_labeled_spans, span2id
+
+
+def serialize_binary_relation(
+    relation_id: str,
+    binary_relation: Union[LabeledMultiSpan, LabeledSpan],
+    span2id: Dict[Annotation, str],
+    label_prefix: Optional[str] = None,
+) -> str:
+    """Serialize a binary relation into a string representation.
+
+    Args:
+        relation_id (str): The identifier for the binary relation.
+        binary_relation (Union[LabeledMultiSpan, LabeledSpan]): The binary relation object to serialize.
+            Labeled Spans in the binary relation can be either a LabeledMultiSpan or a LabeledSpan.
+        span2id (Dict[Annotation, str]): A dictionary mapping span annotations to their IDs.
+        label_prefix (Optional[str], optional): A prefix to be added to the label.
+            Defaults to None.
+
+    Returns:
+        str: The serialized representation of the binary relation.
+
+    Raises:
+        Warning: If the binary relation has an unknown type.
+    """
+    if not isinstance(binary_relation, BinaryRelation):
+        raise Warning(f"relation has unknown type: {type(binary_relation)}")
+
+    arg1 = span2id[binary_relation.head]
+    arg2 = span2id[binary_relation.tail]
+    label = (
+        binary_relation.label
+        if label_prefix is None
+        else f"{label_prefix}-{binary_relation.label}"
+    )
+    serialized_binary_relation = f"{relation_id}\t{label} Arg1:{arg1} Arg2:{arg2}\n"
+    return serialized_binary_relation
 
 
 def serialize_binary_relations(
-    relations: BaseAnnotationList,
+    binary_relations: BaseAnnotationList,
     span2id: Dict[Annotation, str],
     label_prefix: Optional[str] = None,
     first_relation_id: int = 0,
@@ -76,7 +138,7 @@ def serialize_binary_relations(
     e.g: R0 Arg1 Arg2 LABEL
 
     Parameters:
-        relations (BaseAnnotationList): The list of relation annotations.
+        binary_relations (BaseAnnotationList): The list of relation annotations.
         span2id (Dict[Annotation, str]): A dictionary mapping labeled spans to their annotation IDs.
         label_prefix (Optional[str]): An optional prefix to add to relation labels.
         first_relation_id: An integer value used for creating relation annotation IDs. It ensures the proper assignment
@@ -85,18 +147,18 @@ def serialize_binary_relations(
     Returns:
         List[str]: A list of strings representing relation annotations in the Brat format.
     """
-    ann_relations = []
-    for i, relation in enumerate(relations, start=first_relation_id):
-        if not isinstance(relation, BinaryRelation):
-            raise Warning(f"relation has unknown type: {type(relation)}")
+    serialized_binary_relations = []
+    for i, binary_relation in enumerate(binary_relations, start=first_relation_id):
         relation_id = f"R{i}"
-        arg1 = span2id[relation.head]
-        arg2 = span2id[relation.tail]
-        label = relation.label if label_prefix is None else f"{label_prefix}-{relation.label}"
-        entry = f"{relation_id}\t{label} Arg1:{arg1} Arg2:{arg2}\n"
-        ann_relations.append(entry)
+        serialized_binary_relation = serialize_binary_relation(
+            relation_id=relation_id,
+            binary_relation=binary_relation,
+            span2id=span2id,
+            label_prefix=label_prefix,
+        )
+        serialized_binary_relations.append(serialized_binary_relation)
 
-    return ann_relations
+    return serialized_binary_relations
 
 
 def serialize_annotations(
@@ -105,16 +167,29 @@ def serialize_annotations(
     gold_label_prefix: Optional[str] = None,
     prediction_label_prefix: Optional[str] = None,
 ) -> List[str]:
+    """Serialize annotations including labeled spans and binary relations into a list of strings.
+
+    Args:
+        labeled_span_layer (AnnotationLayer): Annotation layer containing labeled spans.
+        binary_relation_layer (AnnotationLayer): Annotation layer containing binary relations.
+        gold_label_prefix (Optional[str], optional): Prefix to be added to gold labels.
+            Defaults to None.
+        prediction_label_prefix (Optional[str], optional): Prefix to be added to prediction labels.
+            Defaults to None.
+
+    Returns:
+        List[str]: List of serialized annotations.
+    """
     serialized_labeled_spans = []
     serialized_binary_relations = []
     if gold_label_prefix is not None:
         serialized_labeled_spans_gold, span2id = serialize_labeled_spans(
-            entities=labeled_span_layer,
+            labeled_spans=labeled_span_layer,
             label_prefix=gold_label_prefix,
         )
         serialized_labeled_spans.extend(serialized_labeled_spans_gold)
         serialized_binary_relations_gold = serialize_binary_relations(
-            relations=binary_relation_layer,
+            binary_relations=binary_relation_layer,
             span2id=span2id,
             label_prefix=gold_label_prefix,
         )
@@ -122,14 +197,14 @@ def serialize_annotations(
     else:
         span2id = {}
     serialized_labeled_spans_pred, span2id_pred = serialize_labeled_spans(
-        entities=labeled_span_layer.predictions,
+        labeled_spans=labeled_span_layer.predictions,
         label_prefix=prediction_label_prefix,
         first_span_id=len(serialized_labeled_spans),
     )
     span2id.update(span2id_pred)
     serialized_labeled_spans.extend(serialized_labeled_spans_pred)
     serialized_binary_relations_pred = serialize_binary_relations(
-        relations=binary_relation_layer.predictions,
+        binary_relations=binary_relation_layer.predictions,
         span2id=span2id,
         label_prefix=prediction_label_prefix,
         first_relation_id=len(serialized_binary_relations),
@@ -139,17 +214,17 @@ def serialize_annotations(
 
 
 class BratSerializer(DocumentSerializer):
-    """BratSerializer serialize documents into the Brat format. It requires a document processor
-    which converts predicted annotations into the desired format. "entity_layer" and
-    "relation_layer" parameters must align with the respective entity and relation annotation layer
-    of resulting document from the document processor. BratSerializer additionally provides the
-    functionality to include both gold and predicted annotations in the resulting annotation file,
-    with the option to differentiate them using the label_prefix.
+    """BratSerializer serialize documents into the Brat format. It requires "entity_layer" and
+    "relation_layer" parameters which defines the entity and relation annotation layer names. If
+    document processor is provided then these parameters must align with the respective entity and
+    relation annotation layer of resulting document from the document processor. BratSerializer
+    additionally provides the functionality to include both gold and predicted annotations in the
+    resulting annotation file, with the option to differentiate them using the label_prefix.
 
     Attributes:
-        document_processor: A function or callable object to process documents before serialization.
         entity_layer: The name of the entity annotation layer.
         relation_layer: The name of the relation annotation layer.
+        document_processor: A function or callable object to process documents before serialization.
         prediction_label_prefix: An optional prefix for labels in predicted annotations.
         gold_label_prefix: An optional prefix for labels in gold annotations.
         default_kwargs: Additional keyword arguments to be used as defaults during serialization.
@@ -157,9 +232,9 @@ class BratSerializer(DocumentSerializer):
 
     def __init__(
         self,
-        document_processor,
         entity_layer,
         relation_layer,
+        document_processor=None,
         prediction_label_prefix=None,
         gold_label_prefix=None,
         **kwargs,
@@ -172,7 +247,8 @@ class BratSerializer(DocumentSerializer):
         self.default_kwargs = kwargs
 
     def __call__(self, documents: Sequence[Document], **kwargs) -> Dict[str, str]:
-        documents = list(map(self.document_processor, documents))
+        if self.document_processor is not None:
+            documents = list(map(self.document_processor, documents))
         return self.write_with_defaults(
             documents=documents,
             entity_layer=self.entity_layer,

--- a/src/serializer/brat.py
+++ b/src/serializer/brat.py
@@ -1,0 +1,297 @@
+import glob
+import json
+import os
+from collections import defaultdict
+from typing import DefaultDict, Dict, List, Optional, Sequence, Type, TypeVar
+
+from pie_datasets.core.dataset_dict import METADATA_FILE_NAME
+from pytorch_ie.annotations import BinaryRelation, LabeledSpan
+from pytorch_ie.core import Document
+from pytorch_ie.utils.hydra import resolve_optional_document_type, serialize_document_type
+
+from src.serializer.interface import DocumentSerializer
+from src.utils import get_pylogger
+
+log = get_pylogger(__name__)
+
+D = TypeVar("D", bound=Document)
+
+
+def get_era(ann_file_path):
+    entities = []
+    relations = []
+    attributes = []
+    with open(ann_file_path, "r") as file:
+        for line in file:
+            if line.startswith("T"):
+                parts = line.split("\t")
+
+                if ";" in parts[1]:
+                    label_ent_1, ent_2 = parts[1].split(";")
+                    label, start_idx_1, end_idx_1 = label_ent_1.split()
+                    start_idx_2, end_idx_2 = ent_2.split()
+                    start_idx_1, end_idx_1 = map(int, (start_idx_1, end_idx_1))
+                    start_idx_2, end_idx_2 = map(int, (start_idx_2, end_idx_2))
+                    text_1, text_2 = (
+                        parts[2][: end_idx_1 - start_idx_1],
+                        parts[2][end_idx_1 - start_idx_1 :],
+                    )
+                    entities.append(
+                        {
+                            "id": parts[0],
+                            "label": label,
+                            "start_idx_1": start_idx_1,
+                            "end_idx_1": end_idx_1,
+                            "start_idx_2": start_idx_2,
+                            "end_idx_2": end_idx_2,
+                            "text_1": text_1.strip(),
+                            "text_2": text_2.strip(),
+                            "len_1": end_idx_1 - start_idx_1,
+                            "len_2": end_idx_2 - start_idx_2,
+                            "multispan": True,
+                        }
+                    )
+                else:
+                    text = parts[2].strip()
+                    label, start_idx, end_idx = parts[1].split()
+                    start_idx, end_idx = map(int, (start_idx, end_idx))
+
+                    entities.append(
+                        {
+                            "id": parts[0],
+                            "label": label,
+                            "start_idx": start_idx,
+                            "end_idx": end_idx,
+                            "text": text,
+                            "len": end_idx - start_idx,
+                            "multispan": False,
+                        }
+                    )
+            elif line.startswith("R"):
+                parts = line.split("\t")
+                label, arg1, arg2 = parts[1].split()
+                arg1 = arg1.split(":")[-1]
+                arg2 = arg2.split(":")[-1]
+                relations.append(
+                    {
+                        "label": label,
+                        "arg1": arg1,
+                        "arg2": arg2,
+                    }
+                )
+            elif line.startswith("A"):
+                parts = line.split("\t")[1].split()
+                if len(parts) == 2:
+
+                    attributes.append(
+                        {
+                            "label": parts[0],
+                            "entity": parts[1],
+                        }
+                    )
+                elif len(parts) == 3:
+                    label, entity, value = line.split("\t")[1].split()
+                    attributes.append(
+                        {
+                            "label": label,
+                            "entity": entity,
+                            "value": value,
+                        }
+                    )
+    return entities, relations, attributes
+
+
+class BratSerializer(DocumentSerializer):
+    def __init__(self, **kwargs):
+        self.default_kwargs = kwargs
+
+    def __call__(self, documents: Sequence[Document], **kwargs) -> Dict[str, str]:
+        return self.write_with_defaults(documents=documents, **kwargs)
+
+    def write_with_defaults(self, **kwargs) -> Dict[str, str]:
+        all_kwargs = {**self.default_kwargs, **kwargs}
+        return self.write(**all_kwargs)
+
+    @classmethod
+    def write(
+        cls,
+        documents: Sequence[Document],
+        path: str,
+        metadata_file_name: str = METADATA_FILE_NAME,
+        split: Optional[str] = None,
+        **kwargs,
+    ) -> Dict[str, str]:
+        realpath = os.path.realpath(path)
+        log.info(f'serialize documents to "{realpath}" ...')
+        os.makedirs(realpath, exist_ok=True)
+
+        if len(documents) == 0:
+            raise Exception("cannot serialize empty list of documents")
+        document_type = type(documents[0])
+        metadata = {"document_type": serialize_document_type(document_type)}
+        full_metadata_file_name = os.path.join(realpath, metadata_file_name)
+
+        if split is not None:
+            realpath = os.path.join(realpath, split)
+            os.makedirs(realpath, exist_ok=True)
+        metadata_text = defaultdict(str)
+        for doc in documents:
+            file_name = f"{doc.id}.ann"
+            metadata_text[f"{file_name}"] = doc.text
+            ann_path = os.path.join(realpath, file_name)
+            with open(ann_path, "w+") as f:
+                entities = doc.entities.predictions
+                relations = doc.relations.predictions
+                entities_to_merge = [
+                    (rel.head, rel.tail) for rel in relations if rel.label == "parts_of_same"
+                ]
+                j = 0
+                span2id: DefaultDict[LabeledSpan, str] = defaultdict()
+                for entity1, entity2 in entities_to_merge:
+
+                    entity_id = f"T{j}"
+
+                    start_idx_1 = entity1.start
+                    end_idx_1 = entity1.end
+                    label1 = entity1.label
+                    entity_text_1 = doc.text[start_idx_1:end_idx_1]
+
+                    start_idx_2 = entity2.start
+                    end_idx_2 = entity2.end
+                    label2 = entity2.label
+                    entity_text_2 = doc.text[start_idx_2:end_idx_2]
+
+                    if label1 != label2:
+                        raise Exception(
+                            "Entities with parts_of_same relation should have same entity type."
+                        )
+
+                    entry = f"{entity_id}\t{label1} {start_idx_1} {end_idx_1};{start_idx_2} {end_idx_2}\t{entity_text_1} {entity_text_2}\n"
+                    span2id[entity1] = entity_id
+                    span2id[entity2] = entity_id
+                    f.write(entry)
+
+                    entities.remove(entity1)
+                    entities.remove(entity2)
+                    j += 1
+
+                for i, entity in enumerate(entities, start=j):
+                    entity_id = f"T{i}"
+                    start_idx = entity.start
+                    end_idx = entity.end
+                    label = entity.label
+                    entity_text = doc.text[start_idx:end_idx]
+                    entry = f"{entity_id}\t{label} {start_idx} {end_idx}\t{entity_text}\n"
+                    span2id[entity] = entity_id
+                    f.write(entry)
+
+                for i, relation in enumerate(relations):
+                    relation_id = f"R{i}"
+                    arg1 = span2id[relation.head]
+                    arg2 = span2id[relation.tail]
+                    label = relation.label
+                    if label == "parts_of_same":
+                        continue
+                    entry = f"{relation_id}\t{label} Arg1:{arg1} Arg2:{arg2}\n"
+                    f.write(entry)
+
+        metadata["text"] = metadata_text
+        print(realpath)
+
+        if os.path.exists(full_metadata_file_name):
+            log.warning(
+                f"metadata file {full_metadata_file_name} already exists, "
+                "it will be overwritten!"
+            )
+        with open(full_metadata_file_name, "w") as f:
+            json.dump(metadata, f, indent=2)
+        return {"path": realpath, "metadata_file_name": metadata_file_name}
+
+    @classmethod
+    def read(
+        cls,
+        path: str,
+        document_type: Optional[Type[D]] = None,
+        metadata_file_name: str = METADATA_FILE_NAME,
+        split: Optional[str] = None,
+    ) -> List[D]:
+        realpath = os.path.realpath(path)
+        log.info(f'load documents from "{realpath}" ...')
+
+        # try to load metadata including the document_type
+        full_metadata_file_name = os.path.join(realpath, metadata_file_name)
+        if os.path.exists(full_metadata_file_name):
+            with open(full_metadata_file_name) as f:
+                metadata = json.load(f)
+            document_type = resolve_optional_document_type(metadata.get("document_type"))
+
+        if document_type is None:
+            raise Exception("document_type is required to load serialized documents")
+
+        if split is not None:
+            realpath = os.path.join(realpath, split)
+        ann_files = glob.glob(os.path.join(realpath, "*.ann"))
+        file_name2text = metadata.get("text")
+        documents = []
+        for ann_file in ann_files:
+            _, file_name = os.path.split(ann_file)
+            doc_text = file_name2text[file_name]
+            entities, relations, attributes = get_era(ann_file)
+            document = document_type(text=doc_text, id=file_name.split(".")[0])
+            idx2entity: DefaultDict[str, LabeledSpan] = defaultdict()
+            candidate_ents = []
+
+            for entity in entities:
+                if entity["multispan"]:
+                    idx = entity["id"]
+                    label = entity["label"]
+                    text_1 = entity["text_1"]
+                    text_2 = entity["text_2"]
+
+                    start_idx_1 = entity["start_idx_1"]
+                    end_idx_1 = entity["end_idx_1"]
+                    start_idx_2 = entity["start_idx_2"]
+                    end_idx_2 = entity["end_idx_2"]
+                    ent1 = LabeledSpan(start=start_idx_1, end=end_idx_1, label=label)
+                    ent2 = LabeledSpan(start=start_idx_2, end=end_idx_2, label=label)
+                    idx2entity[idx] = ent1
+                    idx2entity[idx] = ent2
+                    if (
+                        text_1 != document.text[start_idx_1:end_idx_1]
+                        or text_2 != document.text[start_idx_2:end_idx_2]
+                    ):
+                        raise Exception("TODO:Entity Span mismatch")
+                    document.entities.predictions.append(ent1)
+                    document.entities.predictions.append(ent2)
+                    candidate_ents.append((ent1, ent2))
+                else:
+                    idx = entity["id"]
+                    start = entity["start_idx"]
+                    end = entity["end_idx"]
+                    label = entity["label"]
+                    text = entity["text"]
+                    ent = LabeledSpan(start=start, end=end, label=label)
+                    idx2entity[idx] = ent
+                    if text != document.text[start:end]:
+                        raise Exception("TODO:Entity Span mismatch")
+                    document.entities.predictions.append(ent)
+
+            for relation in relations:
+                head = idx2entity[relation["arg1"]]
+                tail = idx2entity[relation["arg2"]]
+                label = relation["label"]
+                rel = BinaryRelation(head=head, tail=tail, label=label)
+                document.relations.predictions.append(rel)
+
+            if candidate_ents:
+                for ent1, ent2 in candidate_ents:
+                    rel = BinaryRelation(head=ent1, tail=ent2, label="parts_of_same")
+                    document.relations.predictions.append(rel)
+
+            documents.append(document)
+
+        return documents
+
+    def read_with_defaults(self, **kwargs) -> List[D]:
+        all_kwargs = {**self.default_kwargs, **kwargs}
+        return self.read(**all_kwargs)

--- a/src/serializer/brat.py
+++ b/src/serializer/brat.py
@@ -111,26 +111,20 @@ def serialize_annotations(
         serialized_labeled_spans_gold, span2id = serialize_labeled_spans(
             entities=labeled_span_layer,
             label_prefix=gold_label_prefix,
-            first_span_id=0,
         )
         serialized_labeled_spans.extend(serialized_labeled_spans_gold)
         serialized_binary_relations_gold = serialize_binary_relations(
             relations=binary_relation_layer,
             span2id=span2id,
             label_prefix=gold_label_prefix,
-            first_relation_id=0,
         )
         serialized_binary_relations.extend(serialized_binary_relations_gold)
-        last_span_id = len(serialized_labeled_spans_gold)
-        last_rel_id = len(serialized_binary_relations_gold)
     else:
-        last_span_id = 0
-        last_rel_id = 0
         span2id = {}
     serialized_labeled_spans_pred, span2id_pred = serialize_labeled_spans(
         entities=labeled_span_layer.predictions,
         label_prefix=prediction_label_prefix,
-        first_span_id=last_span_id,
+        first_span_id=len(serialized_labeled_spans),
     )
     span2id.update(span2id_pred)
     serialized_labeled_spans.extend(serialized_labeled_spans_pred)
@@ -138,7 +132,7 @@ def serialize_annotations(
         relations=binary_relation_layer.predictions,
         span2id=span2id,
         label_prefix=prediction_label_prefix,
-        first_relation_id=last_rel_id,
+        first_relation_id=len(serialized_binary_relations),
     )
     serialized_binary_relations.extend(serialized_binary_relations_pred)
     return serialized_labeled_spans + serialized_binary_relations

--- a/src/serializer/brat.py
+++ b/src/serializer/brat.py
@@ -89,8 +89,6 @@ def serialize_binary_relation(
     Returns:
         str: The id and serialized representation of the binary relation.
     """
-    if not isinstance(annotation, BinaryRelation):
-        raise Warning(f"relation has unknown type: {type(annotation)}")
 
     arg1 = annotation2id[annotation.head]
     arg2 = annotation2id[annotation.tail]

--- a/src/serializer/brat.py
+++ b/src/serializer/brat.py
@@ -184,7 +184,8 @@ def serialize_annotation_layers(
 
 class BratSerializer(DocumentSerializer):
     """BratSerializer serialize documents into the Brat format. It requires a "layers" parameter to
-    specify the annotation layers to serialize.
+    specify the annotation layers to serialize. For now, it supports layers containing LabeledSpan,
+    LabeledMultiSpan, and BinaryRelation annotations.
 
     If a gold_label_prefix is provided, the gold annotations are serialized with the given prefix.
     Otherwise, only the predicted annotations are serialized. A document_processor can be provided

--- a/src/serializer/brat.py
+++ b/src/serializer/brat.py
@@ -1,13 +1,12 @@
-import glob
 import json
 import os
 from collections import defaultdict
-from typing import DefaultDict, Dict, List, Optional, Sequence, Type, TypeVar
+from typing import DefaultDict, Dict, Optional, Sequence, TypeVar
 
 from pie_datasets.core.dataset_dict import METADATA_FILE_NAME
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
+from pie_modules.annotations import LabeledMultiSpan, LabeledSpan
 from pytorch_ie.core import Document
-from pytorch_ie.utils.hydra import resolve_optional_document_type, serialize_document_type
+from pytorch_ie.utils.hydra import serialize_document_type
 
 from src.serializer.interface import DocumentSerializer
 from src.utils import get_pylogger
@@ -17,96 +16,74 @@ log = get_pylogger(__name__)
 D = TypeVar("D", bound=Document)
 
 
-def get_era(ann_file_path):
-    entities = []
-    relations = []
-    attributes = []
-    with open(ann_file_path, "r") as file:
-        for line in file:
-            if line.startswith("T"):
-                parts = line.split("\t")
+def spans_to_ann_entities(document, entities, label_prefix=None):
+    span2id: DefaultDict[LabeledSpan, str] = defaultdict()
+    ann_entities = []
+    for i, entity in enumerate(entities):
+        entity_id = f"T{i}"
+        label = entity.label if label_prefix is None else f"{label_prefix}-{entity.label}"
+        if isinstance(entity, LabeledMultiSpan):
+            locations = []
+            texts = []
+            for slice in entity.slices:
+                start_idx = slice[0]
+                end_idx = slice[1]
+                texts.append(document.text[start_idx:end_idx])
+                locations.append(f"{start_idx} {end_idx}")
+            location = ";".join(locations)
+            text = " ".join(texts)
+            entry = f"{entity_id}\t{label} {location}\t{text}\n"
+        elif isinstance(entity, LabeledSpan):
+            start_idx = entity.start
+            end_idx = entity.end
+            entity_text = document.text[start_idx:end_idx]
+            entry = f"{entity_id}\t{label} {start_idx} {end_idx}\t{entity_text}\n"
+        else:
+            raise Warning(f"Unknown entity type: {type(entity)}")
+        span2id[entity] = entity_id
+        ann_entities.append(entry)
+    return ann_entities, span2id
 
-                if ";" in parts[1]:
-                    label_ent_1, ent_2 = parts[1].split(";")
-                    label, start_idx_1, end_idx_1 = label_ent_1.split()
-                    start_idx_2, end_idx_2 = ent_2.split()
-                    start_idx_1, end_idx_1 = map(int, (start_idx_1, end_idx_1))
-                    start_idx_2, end_idx_2 = map(int, (start_idx_2, end_idx_2))
-                    text_1, text_2 = (
-                        parts[2][: end_idx_1 - start_idx_1],
-                        parts[2][end_idx_1 - start_idx_1 :],
-                    )
-                    entities.append(
-                        {
-                            "id": parts[0],
-                            "label": label,
-                            "start_idx_1": start_idx_1,
-                            "end_idx_1": end_idx_1,
-                            "start_idx_2": start_idx_2,
-                            "end_idx_2": end_idx_2,
-                            "text_1": text_1.strip(),
-                            "text_2": text_2.strip(),
-                            "len_1": end_idx_1 - start_idx_1,
-                            "len_2": end_idx_2 - start_idx_2,
-                            "multispan": True,
-                        }
-                    )
-                else:
-                    text = parts[2].strip()
-                    label, start_idx, end_idx = parts[1].split()
-                    start_idx, end_idx = map(int, (start_idx, end_idx))
 
-                    entities.append(
-                        {
-                            "id": parts[0],
-                            "label": label,
-                            "start_idx": start_idx,
-                            "end_idx": end_idx,
-                            "text": text,
-                            "len": end_idx - start_idx,
-                            "multispan": False,
-                        }
-                    )
-            elif line.startswith("R"):
-                parts = line.split("\t")
-                label, arg1, arg2 = parts[1].split()
-                arg1 = arg1.split(":")[-1]
-                arg2 = arg2.split(":")[-1]
-                relations.append(
-                    {
-                        "label": label,
-                        "arg1": arg1,
-                        "arg2": arg2,
-                    }
-                )
-            elif line.startswith("A"):
-                parts = line.split("\t")[1].split()
-                if len(parts) == 2:
+def relations_to_ann_relations(relations, span2id, label_prefix=None):
+    ann_relations = []
+    for i, relation in enumerate(relations):
+        relation_id = f"R{i}"
+        arg1 = span2id[relation.head]
+        arg2 = span2id[relation.tail]
+        label = relation.label if label_prefix is None else f"{label_prefix}-{relation.label}"
+        entry = f"{relation_id}\t{label} Arg1:{arg1} Arg2:{arg2}\n"
+        ann_relations.append(entry)
 
-                    attributes.append(
-                        {
-                            "label": parts[0],
-                            "entity": parts[1],
-                        }
-                    )
-                elif len(parts) == 3:
-                    label, entity, value = line.split("\t")[1].split()
-                    attributes.append(
-                        {
-                            "label": label,
-                            "entity": entity,
-                            "value": value,
-                        }
-                    )
-    return entities, relations, attributes
+    return ann_relations
+
+
+def write_annotations_to_file(document, entities, relations, file_descriptor, label_prefix):
+    ann_entities, span2id = spans_to_ann_entities(document, entities, label_prefix=label_prefix)
+    ann_relations = relations_to_ann_relations(relations, span2id)
+    for ann_entity in ann_entities:
+        file_descriptor.write(ann_entity)
+    for ann_relation in ann_relations:
+        file_descriptor.write(ann_relation)
 
 
 class BratSerializer(DocumentSerializer):
-    def __init__(self, **kwargs):
+    def __init__(
+        self, document_processor, prediction_label_prefix=None, gold_label_prefix=None, **kwargs
+    ):
+        self.document_processor = document_processor
+        self.prediction_label_prefix = prediction_label_prefix
+        self.gold_label_prefix = gold_label_prefix
         self.default_kwargs = kwargs
 
     def __call__(self, documents: Sequence[Document], **kwargs) -> Dict[str, str]:
-        return self.write_with_defaults(documents=documents, **kwargs)
+        documents = list(map(self.document_processor, documents))
+        return self.write_with_defaults(
+            documents=documents,
+            prediction_label_prefix=self.prediction_label_prefix,
+            gold_label_prefix=self.gold_label_prefix,
+            **kwargs,
+        )
 
     def write_with_defaults(self, **kwargs) -> Dict[str, str]:
         all_kwargs = {**self.default_kwargs, **kwargs}
@@ -119,8 +96,11 @@ class BratSerializer(DocumentSerializer):
         path: str,
         metadata_file_name: str = METADATA_FILE_NAME,
         split: Optional[str] = None,
+        gold_label_prefix=None,
+        prediction_label_prefix=None,
         **kwargs,
     ) -> Dict[str, str]:
+
         realpath = os.path.realpath(path)
         log.info(f'serialize documents to "{realpath}" ...')
         os.makedirs(realpath, exist_ok=True)
@@ -140,60 +120,15 @@ class BratSerializer(DocumentSerializer):
             metadata_text[f"{file_name}"] = doc.text
             ann_path = os.path.join(realpath, file_name)
             with open(ann_path, "w+") as f:
-                entities = doc.entities.predictions
-                relations = doc.relations.predictions
-                entities_to_merge = [
-                    (rel.head, rel.tail) for rel in relations if rel.label == "parts_of_same"
-                ]
-                j = 0
-                span2id: DefaultDict[LabeledSpan, str] = defaultdict()
-                for entity1, entity2 in entities_to_merge:
-
-                    entity_id = f"T{j}"
-
-                    start_idx_1 = entity1.start
-                    end_idx_1 = entity1.end
-                    label1 = entity1.label
-                    entity_text_1 = doc.text[start_idx_1:end_idx_1]
-
-                    start_idx_2 = entity2.start
-                    end_idx_2 = entity2.end
-                    label2 = entity2.label
-                    entity_text_2 = doc.text[start_idx_2:end_idx_2]
-
-                    if label1 != label2:
-                        raise Exception(
-                            "Entities with parts_of_same relation should have same entity type."
-                        )
-
-                    entry = f"{entity_id}\t{label1} {start_idx_1} {end_idx_1};{start_idx_2} {end_idx_2}\t{entity_text_1} {entity_text_2}\n"
-                    span2id[entity1] = entity_id
-                    span2id[entity2] = entity_id
-                    f.write(entry)
-
-                    entities.remove(entity1)
-                    entities.remove(entity2)
-                    j += 1
-
-                for i, entity in enumerate(entities, start=j):
-                    entity_id = f"T{i}"
-                    start_idx = entity.start
-                    end_idx = entity.end
-                    label = entity.label
-                    entity_text = doc.text[start_idx:end_idx]
-                    entry = f"{entity_id}\t{label} {start_idx} {end_idx}\t{entity_text}\n"
-                    span2id[entity] = entity_id
-                    f.write(entry)
-
-                for i, relation in enumerate(relations):
-                    relation_id = f"R{i}"
-                    arg1 = span2id[relation.head]
-                    arg2 = span2id[relation.tail]
-                    label = relation.label
-                    if label == "parts_of_same":
-                        continue
-                    entry = f"{relation_id}\t{label} Arg1:{arg1} Arg2:{arg2}\n"
-                    f.write(entry)
+                if gold_label_prefix is not None:
+                    entities = doc.spans
+                    relations = doc.relations
+                    write_annotations_to_file(doc, entities, relations, f, gold_label_prefix)
+                if prediction_label_prefix is not None:
+                    entities = doc.spans.predictions
+                    relations = doc.relations.predictions
+                    write_annotations_to_file(doc, entities, relations, f, prediction_label_prefix)
+            f.close()
 
         metadata["text"] = metadata_text
         print(realpath)
@@ -206,92 +141,3 @@ class BratSerializer(DocumentSerializer):
         with open(full_metadata_file_name, "w") as f:
             json.dump(metadata, f, indent=2)
         return {"path": realpath, "metadata_file_name": metadata_file_name}
-
-    @classmethod
-    def read(
-        cls,
-        path: str,
-        document_type: Optional[Type[D]] = None,
-        metadata_file_name: str = METADATA_FILE_NAME,
-        split: Optional[str] = None,
-    ) -> List[D]:
-        realpath = os.path.realpath(path)
-        log.info(f'load documents from "{realpath}" ...')
-
-        # try to load metadata including the document_type
-        full_metadata_file_name = os.path.join(realpath, metadata_file_name)
-        if os.path.exists(full_metadata_file_name):
-            with open(full_metadata_file_name) as f:
-                metadata = json.load(f)
-            document_type = resolve_optional_document_type(metadata.get("document_type"))
-
-        if document_type is None:
-            raise Exception("document_type is required to load serialized documents")
-
-        if split is not None:
-            realpath = os.path.join(realpath, split)
-        ann_files = glob.glob(os.path.join(realpath, "*.ann"))
-        file_name2text = metadata.get("text")
-        documents = []
-        for ann_file in ann_files:
-            _, file_name = os.path.split(ann_file)
-            doc_text = file_name2text[file_name]
-            entities, relations, attributes = get_era(ann_file)
-            document = document_type(text=doc_text, id=file_name.split(".")[0])
-            idx2entity: DefaultDict[str, LabeledSpan] = defaultdict()
-            candidate_ents = []
-
-            for entity in entities:
-                if entity["multispan"]:
-                    idx = entity["id"]
-                    label = entity["label"]
-                    text_1 = entity["text_1"]
-                    text_2 = entity["text_2"]
-
-                    start_idx_1 = entity["start_idx_1"]
-                    end_idx_1 = entity["end_idx_1"]
-                    start_idx_2 = entity["start_idx_2"]
-                    end_idx_2 = entity["end_idx_2"]
-                    ent1 = LabeledSpan(start=start_idx_1, end=end_idx_1, label=label)
-                    ent2 = LabeledSpan(start=start_idx_2, end=end_idx_2, label=label)
-                    idx2entity[idx] = ent1
-                    idx2entity[idx] = ent2
-                    if (
-                        text_1 != document.text[start_idx_1:end_idx_1]
-                        or text_2 != document.text[start_idx_2:end_idx_2]
-                    ):
-                        raise Exception("TODO:Entity Span mismatch")
-                    document.entities.predictions.append(ent1)
-                    document.entities.predictions.append(ent2)
-                    candidate_ents.append((ent1, ent2))
-                else:
-                    idx = entity["id"]
-                    start = entity["start_idx"]
-                    end = entity["end_idx"]
-                    label = entity["label"]
-                    text = entity["text"]
-                    ent = LabeledSpan(start=start, end=end, label=label)
-                    idx2entity[idx] = ent
-                    if text != document.text[start:end]:
-                        raise Exception("TODO:Entity Span mismatch")
-                    document.entities.predictions.append(ent)
-
-            for relation in relations:
-                head = idx2entity[relation["arg1"]]
-                tail = idx2entity[relation["arg2"]]
-                label = relation["label"]
-                rel = BinaryRelation(head=head, tail=tail, label=label)
-                document.relations.predictions.append(rel)
-
-            if candidate_ents:
-                for ent1, ent2 in candidate_ents:
-                    rel = BinaryRelation(head=ent1, tail=ent2, label="parts_of_same")
-                    document.relations.predictions.append(rel)
-
-            documents.append(document)
-
-        return documents
-
-    def read_with_defaults(self, **kwargs) -> List[D]:
-        all_kwargs = {**self.default_kwargs, **kwargs}
-        return self.read(**all_kwargs)

--- a/tests/unit/serializer/test_brat.py
+++ b/tests/unit/serializer/test_brat.py
@@ -1,88 +1,27 @@
 import os
-from collections import defaultdict as dd
 from dataclasses import dataclass
 from typing import TypeVar
 
-from pie_datasets.builders.brat import BratDocument
-from pie_modules.document.processing import SpansViaRelationMerger
+import pytest
+from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
+from pie_modules.documents import (
+    TextBasedDocument,
+    TextDocumentWithLabeledSpansAndBinaryRelations,
+    TokenDocumentWithLabeledSpansAndBinaryRelations,
+)
 from pytorch_ie import AnnotationLayer
-from pytorch_ie.core import Document
+from pytorch_ie.core import Document, annotation_field
 
+from src.serializer import BratSerializer
+from src.serializer.brat import (
+    serialize_annotations,
+    serialize_binary_relation,
+    serialize_labeled_span,
+)
 from src.utils import get_pylogger
 
 log = get_pylogger(__name__)
-
 D = TypeVar("D", bound=Document)
-import pytest
-from pytorch_ie.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
-from pytorch_ie.core import annotation_field
-from pytorch_ie.documents import TextBasedDocument, TextDocumentWithLabeledSpansAndBinaryRelations
-
-from src.serializer import BratSerializer
-
-
-def get_location(location_string):
-    parts = location_string.split(" ")
-    assert (
-        len(parts) == 2
-    ), f"Wrong number of entries in location string. Expected 2, but found: {parts}"
-    return {"start": int(parts[0]), "end": int(parts[1])}
-
-
-def get_span_annotation(annotation_line):
-    """example input:
-
-    T1  Organization 0 4        Sony
-    """
-
-    _id, remaining, text = annotation_line.split("\t", maxsplit=2)
-    _type, locations = remaining.split(" ", maxsplit=1)
-    return {
-        "id": _id,
-        "text": text,
-        "type": _type,
-        "locations": [get_location(loc) for loc in locations.split(";")],
-    }
-
-
-def get_relation_annotation(annotation_line):
-    """example input:
-
-    R1  Origin Arg1:T3 Arg2:T4
-    """
-
-    _id, remaining = annotation_line.strip().split("\t")
-    _type, remaining = remaining.split(" ", maxsplit=1)
-    args = [dict(zip(["type", "target"], a.split(":"))) for a in remaining.split(" ")]
-    return {"id": _id, "type": _type, "arguments": args}
-
-
-def read_annotation_file(filename):
-    res = {
-        "spans": [],
-        "relations": [],
-    }
-    with open(filename, encoding="utf-8") as file:
-        for i, line in enumerate(file):
-            if len(line.strip()) == 0:
-                continue
-            ann_type = line[0]
-            # strip away the new line character
-            if line.endswith("\n"):
-                line = line[:-1]
-            if ann_type == "T":
-                res["spans"].append(get_span_annotation(line))
-            elif ann_type == "R":
-                res["relations"].append(get_relation_annotation(line))
-            else:
-                raise ValueError(
-                    f'unknown BRAT annotation id type: "{line}" (from file {filename} @line {i}). '
-                    f"Annotation ids have to start with T (spans), E (events), R (relations), "
-                    f"A (attributions), or N (normalizations). See "
-                    f"https://brat.nlplab.org/standoff.html for the BRAT annotation file "
-                    f"specification."
-                )
-    return res
 
 
 @dataclass
@@ -92,398 +31,253 @@ class TextDocumentWithLabeledMultiSpansAndBinaryRelations(TextBasedDocument):
 
 
 @pytest.fixture
-def document_processor():
-    dp = SpansViaRelationMerger(
-        relation_layer="binary_relations",
-        link_relation_label="parts_of_same",
-        result_document_type=BratDocument,
-        result_field_mapping={"labeled_spans": "spans", "binary_relations": "relations"},
-    )
-
-    return dp
-
-
-@pytest.fixture
 def document():
-    document = TextDocumentWithLabeledSpansAndBinaryRelations(
-        text="Harry lives in Berlin. He works at DFKI.", id="tmp_1"
-    )
-
-    document.labeled_spans.predictions.extend(
-        [
-            LabeledSpan(start=0, end=5, label="PERSON"),  # Harry
-            LabeledSpan(start=15, end=21, label="LOCATION"),  # Berlin
-        ]
-    )
-
-    document.labeled_spans.extend(
-        [
-            LabeledSpan(start=0, end=5, label="PERSON"),  # Harry
-            LabeledSpan(start=15, end=21, label="LOCATION"),  # Berlin
-            LabeledSpan(start=35, end=39, label="ORGANIZATION"),  # DFKI
-        ]
-    )
-
-    document.binary_relations.predictions.extend(
-        [
-            BinaryRelation(
-                head=document.labeled_spans[0], tail=document.labeled_spans[1], label="lives_in"
-            ),
-        ]
-    )
-    document.binary_relations.extend(
-        [
-            BinaryRelation(
-                head=document.labeled_spans[0], tail=document.labeled_spans[1], label="lives_in"
-            ),
-            BinaryRelation(
-                head=document.labeled_spans[0], tail=document.labeled_spans[2], label="works_at"
-            ),
-        ]
-    )
-
-    return document
-
-
-def test_save(tmp_path, document, document_processor):
-    path = str(tmp_path)
-    serializer = BratSerializer(
-        path=path,
-        document_processor=document_processor,
-        entity_layer="spans",
-        relation_layer="relations",
-    )
-
-    metadata = serializer(documents=[document])
-
-    path = metadata["path"]
-    res = read_annotation_file(os.path.join(path, f"{document.id}.ann"))
-    """
-        res in the following format:
-        {'spans':
-            [
-                {'id': 'T0', 'text': 'Harry', 'type': 'PERSON', 'locations': [{'start': 0, 'end': 5}]},
-                {'id': 'T1', 'text': 'DFKI', 'type': 'ORGANIZATION', 'locations': [{'start': 35, 'end': 39}]},
-                {'id': 'T2', 'text': 'Berlin', 'type': 'LOCATION', 'locations': [{'start': 15, 'end': 21}]}
-            ],
-        'relations':
-            [
-                {'id': 'R0', 'type': 'lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T0'},
-                    {'type': 'Arg2', 'target': 'T2'}]},
-                {'id': 'R1', 'type': 'works_at', 'arguments': [{'type': 'Arg1', 'target': 'T0'},
-                    {'type': 'Arg2', 'target': 'T1'}]}
-            ]
-        }
-        """
-    spans = res["spans"]
-    original_spans = document.labeled_spans.predictions
-    assert len(spans) == len(original_spans)
-
-    sorted_spans = sorted(
-        spans, key=lambda x: x["locations"][0]["start"]
-    )  # sort by start index of first span
-    sorted_original_spans = sorted(original_spans, key=lambda x: x.start)  # sort by start index
-    spanid2span = dd()  # map span_id (T0,T1,..) to original span
-    for span, original_span in zip(sorted_spans, sorted_original_spans):
-        assert span["locations"][0]["start"] == original_span.start
-        assert span["locations"][0]["end"] == original_span.end
-        assert span["type"] == original_span.label
-        assert span["text"] == document.text[original_span.start : original_span.end]
-
-        spanid2span[span["id"]] = original_span
-
-    relations = res["relations"]
-    original_relations = document.binary_relations.predictions
-    assert len(relations) == len(original_relations)
-
-    sorted_relations = sorted(relations, key=lambda x: x["type"])  # sort by relation label
-    sorted_original_relations = sorted(original_relations, key=lambda x: x.label)
-
-    for relation, original_relation in zip(sorted_relations, sorted_original_relations):
-        assert relation["type"] == original_relation.label
-        assert spanid2span[relation["arguments"][0]["target"]] == original_relation.head
-        assert spanid2span[relation["arguments"][1]["target"]] == original_relation.tail
-
-
-def test_save_gold_annotation_with_prefix(tmp_path, document, document_processor):
-    path = str(tmp_path)
-    serializer = BratSerializer(
-        path=path,
-        document_processor=document_processor,
-        entity_layer="spans",
-        relation_layer="relations",
-        gold_label_prefix="GOLD",
-    )
-
-    metadata = serializer(documents=[document])
-
-    path = metadata["path"]
-    res = read_annotation_file(os.path.join(path, f"{document.id}.ann"))
-    """
-    res in the following format:
-    {
-        'spans':
-            [
-                {'id': 'T0', 'text': 'Berlin', 'type': 'GOLD-LOCATION', 'locations': [{'start': 15, 'end': 21}]},
-                {'id': 'T1', 'text': 'Harry', 'type': 'GOLD-PERSON', 'locations': [{'start': 0, 'end': 5}]},
-                {'id': 'T2', 'text': 'DFKI', 'type': 'GOLD-ORGANIZATION', 'locations': [{'start': 35, 'end': 39}]},
-                {'id': 'T3', 'text': 'Berlin', 'type': 'LOCATION', 'locations': [{'start': 15, 'end': 21}]},
-                {'id': 'T4', 'text': 'Harry', 'type': 'PERSON', 'locations': [{'start': 0, 'end': 5}]}
-            ],
-        'relations':
-            [
-                {'id': 'R0', 'type': 'GOLD-lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T1'},
-                    {'type': 'Arg2', 'target': 'T0'}]},
-                {'id': 'R1', 'type': 'GOLD-works_at', 'arguments': [{'type': 'Arg1', 'target': 'T1'},
-                    {'type': 'Arg2', 'target': 'T2'}]},
-                {'id': 'R3', 'type': 'lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T4'},
-                    {'type': 'Arg2', 'target': 'T3'}]}
-            ]
-    }
-
-    """
-    spans = res["spans"]
-    sorted_spans = sorted(spans, key=lambda x: x["type"])[
-        :3
-    ]  # only first three are gold annotations
-    original_spans = document.labeled_spans
-    sorted_original_spans = sorted(original_spans, key=lambda x: x.label)
-    assert len(sorted_spans) == len(sorted_original_spans)
-
-    spanid2span = dd()
-    for span, original_span in zip(sorted_spans, sorted_original_spans):
-        assert span["locations"][0]["start"] == original_span.start
-        assert span["locations"][0]["end"] == original_span.end
-        assert span["type"] == f"GOLD-{original_span.label}"
-        assert span["text"] == document.text[original_span.start : original_span.end]
-
-        spanid2span[span["id"]] = original_span
-
-    relations = res["relations"]
-    sorted_relations = sorted(relations, key=lambda x: x["type"])[
-        :2
-    ]  # only first two are gold annotations
-    original_relations = document.binary_relations
-    sorted_original_relations = sorted(original_relations, key=lambda x: x.label)
-    assert len(sorted_relations) == len(sorted_original_relations)
-
-    for relation, original_relation in zip(sorted_relations, sorted_original_relations):
-        assert relation["type"] == f"GOLD-{original_relation.label}"
-        assert spanid2span[relation["arguments"][0]["target"]] == original_relation.head
-        assert spanid2span[relation["arguments"][1]["target"]] == original_relation.tail
-
-
-def test_save_gold_and_predicted_annotation_with_prefix(tmp_path, document, document_processor):
-    path = str(tmp_path)
-    serializer = BratSerializer(
-        path=path,
-        document_processor=document_processor,
-        entity_layer="spans",
-        relation_layer="relations",
-        gold_label_prefix="GOLD",
-        prediction_label_prefix="PRED",
-    )
-
-    metadata = serializer(documents=[document])
-
-    path = metadata["path"]
-    res = read_annotation_file(os.path.join(path, f"{document.id}.ann"))
-    """
-    res in the following format:
-    {
-        'spans':
-            [
-                {'id': 'T0', 'text': 'Berlin', 'type': 'GOLD-LOCATION', 'locations': [{'start': 15, 'end': 21}]},
-                {'id': 'T1', 'text': 'Harry', 'type': 'GOLD-PERSON', 'locations': [{'start': 0, 'end': 5}]},
-                {'id': 'T2', 'text': 'DFKI', 'type': 'GOLD-ORGANIZATION', 'locations': [{'start': 35, 'end': 39}]},
-                {'id': 'T3', 'text': 'Berlin', 'type': 'PRED-LOCATION', 'locations': [{'start': 15, 'end': 21}]},
-                {'id': 'T4', 'text': 'Harry', 'type': 'PRED-PERSON', 'locations': [{'start': 0, 'end': 5}]}
-            ],
-        'relations':
-            [
-                {'id': 'R0', 'type': 'GOLD-lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T1'},
-                    {'type': 'Arg2', 'target': 'T0'}]},
-                {'id': 'R1', 'type': 'GOLD-works_at', 'arguments': [{'type': 'Arg1', 'target': 'T1'},
-                    {'type': 'Arg2', 'target': 'T2'}]},
-                {'id': 'R3', 'type': 'PRED-lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T4'},
-                    {'type': 'Arg2', 'target': 'T3'}]}
-            ]
-    }
-
-    """
-    spans = res["spans"]
-    sorted_spans = sorted(spans, key=lambda x: x["type"])
-
-    gold_spans = sorted_spans[:3]  # only first three are gold annotations
-    original_gold_spans = document.labeled_spans
-    sorted_original_gold_spans = sorted(original_gold_spans, key=lambda x: x.label)
-    assert len(gold_spans) == len(sorted_original_gold_spans)
-
-    spanid2span = dd()
-    for span, original_span in zip(gold_spans, sorted_original_gold_spans):
-        assert span["locations"][0]["start"] == original_span.start
-        assert span["locations"][0]["end"] == original_span.end
-        assert span["type"] == f"GOLD-{original_span.label}"
-        assert span["text"] == document.text[original_span.start : original_span.end]
-
-        spanid2span[span["id"]] = original_span
-
-    predicted_spans = sorted_spans[3:]  # last two are predicted annotations
-    original_predicted_spans = document.labeled_spans.predictions
-    sorted_original_predicted_spans = sorted(original_predicted_spans, key=lambda x: x.label)
-    assert len(predicted_spans) == len(sorted_original_predicted_spans)
-
-    for span, original_span in zip(predicted_spans, sorted_original_predicted_spans):
-        assert span["locations"][0]["start"] == original_span.start
-        assert span["locations"][0]["end"] == original_span.end
-        assert span["type"] == f"PRED-{original_span.label}"
-        assert span["text"] == document.text[original_span.start : original_span.end]
-
-        spanid2span[span["id"]] = original_span
-
-    relations = res["relations"]
-    sorted_relations = sorted(relations, key=lambda x: x["type"])
-
-    gold_relations = sorted_relations[:2]  # only first two are gold annotations
-    original_gold_relations = document.binary_relations
-    sorted_original_relations = sorted(original_gold_relations, key=lambda x: x.label)
-    assert len(gold_relations) == len(sorted_original_relations)
-
-    for relation, original_relation in zip(gold_relations, sorted_original_relations):
-        assert relation["type"] == f"GOLD-{original_relation.label}"
-        assert spanid2span[relation["arguments"][0]["target"]] == original_relation.head
-        assert spanid2span[relation["arguments"][1]["target"]] == original_relation.tail
-
-    predicted_relations = sorted_relations[2:]  # only last annotation is predicted annotation
-    original_predicted_relations = document.binary_relations.predictions
-    sorted_original_relations = sorted(original_predicted_relations, key=lambda x: x.label)
-    assert len(predicted_relations) == len(sorted_original_relations)
-
-    for relation, original_relation in zip(predicted_relations, sorted_original_relations):
-        assert relation["type"] == f"PRED-{original_relation.label}"
-        assert spanid2span[relation["arguments"][0]["target"]] == original_relation.head
-        assert spanid2span[relation["arguments"][1]["target"]] == original_relation.tail
-
-
-@pytest.fixture
-def document_with_multispan():
     document = TextDocumentWithLabeledSpansAndBinaryRelations(
         text="Harry lives in Berlin, Germany. He works at DFKI.", id="tmp"
     )
     document.labeled_spans.predictions.extend(
         [
             LabeledSpan(start=0, end=5, label="PERSON"),
-            LabeledSpan(start=15, end=21, label="LOCATION"),
-            LabeledSpan(start=23, end=30, label="LOCATION"),
             LabeledSpan(start=44, end=48, label="ORGANIZATION"),
         ]
     )
-    # add relations as predictions
+
+    assert str(document.labeled_spans.predictions[0]) == "Harry"
+    assert str(document.labeled_spans.predictions[1]) == "DFKI"
+
+    document.labeled_spans.extend(
+        [
+            LabeledSpan(start=0, end=5, label="PERSON"),
+            LabeledMultiSpan(slices=((15, 21), (23, 30)), label="LOCATION"),
+            LabeledSpan(start=44, end=48, label="ORGANIZATION"),
+        ]
+    )
+    assert str(document.labeled_spans[0]) == "Harry"
+    assert str(document.labeled_spans[1]) == "('Berlin', 'Germany')"
+    assert str(document.labeled_spans[2]) == "DFKI"
 
     document.binary_relations.predictions.extend(
         [
             BinaryRelation(
-                head=document.labeled_spans.predictions[0],
-                tail=document.labeled_spans.predictions[1],
+                head=document.labeled_spans[0],
+                tail=document.labeled_spans[2],
+                label="works_at",
+            ),
+        ]
+    )
+
+    document.binary_relations.extend(
+        [
+            BinaryRelation(
+                head=document.labeled_spans[0],
+                tail=document.labeled_spans[1],
                 label="lives_in",
             ),
             BinaryRelation(
-                head=document.labeled_spans.predictions[1],
-                tail=document.labeled_spans.predictions[2],
-                label="parts_of_same",
-            ),  # should be removed
-            BinaryRelation(
-                head=document.labeled_spans.predictions[1],
-                tail=document.labeled_spans.predictions[3],
-                label="parts_of_same",
-            ),  # should be removed
-            BinaryRelation(
-                head=document.labeled_spans.predictions[0],
-                tail=document.labeled_spans.predictions[3],
+                head=document.labeled_spans[0],
+                tail=document.labeled_spans[2],
                 label="works_at",
             ),
-            BinaryRelation(
-                head=document.labeled_spans.predictions[3],
-                tail=document.labeled_spans.predictions[1],
-                label="located_in",
-            ),  # tail should be a new merged entity
-            BinaryRelation(
-                head=document.labeled_spans.predictions[3],
-                tail=document.labeled_spans.predictions[2],
-                label="located_in",
-            ),  # tail should be a new merged entity
         ]
     )
 
     return document
 
 
-def test_save_multispan(tmp_path, document_with_multispan, document_processor):
+def test_serialize_labeled_span(document):
+    # labeled span
+    labeled_span = document.labeled_spans[0]
+    serialized_labeled_span = serialize_labeled_span(
+        span_id="T1",
+        labeled_span=labeled_span,
+    )
+
+    assert serialized_labeled_span == "T1\tPERSON 0 5\tHarry\n"
+
+    # labeled multi span
+    labeled_span = document.labeled_spans[1]
+    serialized_labeled_span = serialize_labeled_span(
+        span_id="T2",
+        labeled_span=labeled_span,
+    )
+
+    assert serialized_labeled_span == "T2\tLOCATION 15 21;23 30\tBerlin Germany\n"
+
+    # Unknown type
+    with pytest.raises(Warning) as w:
+        serialize_labeled_span(
+            span_id="T0",
+            labeled_span=document.binary_relations[0],
+        )
+    assert (
+        str(w.value)
+        == "labeled span has unknown type: <class 'pytorch_ie.annotations.BinaryRelation'>"
+    )
+
+
+def test_serialize_binary_relation(document):
+    binary_relation = document.binary_relations[0]
+    span2id = {binary_relation.head: "T1", binary_relation.tail: "T2"}
+    serialized_binary_relation = serialize_binary_relation(
+        relation_id="R1",
+        binary_relation=binary_relation,
+        span2id=span2id,
+    )
+
+    assert serialized_binary_relation == "R1\tlives_in Arg1:T1 Arg2:T2\n"
+
+    # Unknown relation type
+    with pytest.raises(Warning) as w:
+        serialize_binary_relation(relation_id=0, binary_relation=None, span2id={})
+    assert str(w.value) == "relation has unknown type: <class 'NoneType'>"
+
+
+@pytest.fixture
+def serialized_annotations(
+    document,
+    gold_label_prefix=None,
+    prediction_label_prefix=None,
+):
+    return serialize_annotations(
+        labeled_span_layer=document.labeled_spans,
+        binary_relation_layer=document.binary_relations,
+        gold_label_prefix=gold_label_prefix,
+        prediction_label_prefix=prediction_label_prefix,
+    )
+
+
+@pytest.mark.parametrize(
+    "gold_label_prefix, prediction_label_prefix",
+    [(None, None), ("GOLD", None), (None, "PRED"), ("GOLD", "PRED")],
+)
+def test_serialize_annotations(document, gold_label_prefix, prediction_label_prefix):
+    serialized_annotations = serialize_annotations(
+        labeled_span_layer=document.labeled_spans,
+        binary_relation_layer=document.binary_relations,
+        gold_label_prefix=gold_label_prefix,
+        prediction_label_prefix=prediction_label_prefix,
+    )
+
+    if gold_label_prefix == "GOLD" and prediction_label_prefix == "PRED":
+        assert len(serialized_annotations) == 8
+        assert serialized_annotations == [
+            "T0\tGOLD-PERSON 0 5\tHarry\n",
+            "T1\tGOLD-LOCATION 15 21;23 30\tBerlin Germany\n",
+            "T2\tGOLD-ORGANIZATION 44 48\tDFKI\n",
+            "T3\tPRED-PERSON 0 5\tHarry\n",
+            "T4\tPRED-ORGANIZATION 44 48\tDFKI\n",
+            "R0\tGOLD-lives_in Arg1:T0 Arg2:T1\n",
+            "R1\tGOLD-works_at Arg1:T0 Arg2:T2\n",
+            "R2\tPRED-works_at Arg1:T3 Arg2:T4\n",
+        ]
+    elif gold_label_prefix == "GOLD" and prediction_label_prefix is None:
+        assert len(serialized_annotations) == 8
+        assert serialized_annotations == [
+            "T0\tGOLD-PERSON 0 5\tHarry\n",
+            "T1\tGOLD-LOCATION 15 21;23 30\tBerlin Germany\n",
+            "T2\tGOLD-ORGANIZATION 44 48\tDFKI\n",
+            "T3\tPERSON 0 5\tHarry\n",
+            "T4\tORGANIZATION 44 48\tDFKI\n",
+            "R0\tGOLD-lives_in Arg1:T0 Arg2:T1\n",
+            "R1\tGOLD-works_at Arg1:T0 Arg2:T2\n",
+            "R2\tworks_at Arg1:T3 Arg2:T4\n",
+        ]
+    elif gold_label_prefix is None and prediction_label_prefix == "PRED":
+        assert len(serialized_annotations) == 3
+        assert serialized_annotations == [
+            "T0\tPRED-PERSON 0 5\tHarry\n",
+            "T1\tPRED-ORGANIZATION 44 48\tDFKI\n",
+            "R0\tPRED-works_at Arg1:T0 Arg2:T1\n",
+        ]
+    else:
+        assert len(serialized_annotations) == 3
+        assert serialized_annotations == [
+            "T0\tPERSON 0 5\tHarry\n",
+            "T1\tORGANIZATION 44 48\tDFKI\n",
+            "R0\tworks_at Arg1:T0 Arg2:T1\n",
+        ]
+
+
+def document_processor(document) -> TextBasedDocument:
+    # document.copy doesn't work with LabeledMultiSpan,
+    # throws error: TypeError: __init__() got an unexpected keyword argument 'slices'
+    doc = document
+    doc["labeled_spans"].append(LabeledSpan(start=0, end=0, label="empty"))
+    return doc
+
+
+def test_write(tmp_path, document, serialized_annotations):
     path = str(tmp_path)
     serializer = BratSerializer(
         path=path,
         document_processor=document_processor,
-        entity_layer="spans",
-        relation_layer="relations",
+        entity_layer="labeled_spans",
+        relation_layer="binary_relations",
     )
 
-    metadata = serializer(documents=[document_with_multispan])
-
+    metadata = serializer(documents=[document])
     path = metadata["path"]
-    res = read_annotation_file(os.path.join(path, f"{document_with_multispan.id}.ann"))
+    ann_file = os.path.join(path, f"{document.id}.ann")
 
-    """
-    {
-        'spans':
-            [
-                {'id': 'T0', 'text': 'DFKI', 'type': 'ORGANIZATION', 'locations': [{'start': 44, 'end': 48}]},
-                {'id': 'T1', 'text': 'Harry', 'type': 'PERSON', 'locations': [{'start': 0, 'end': 5}]},
-                {'id': 'T2', 'text': 'Berlin Germany', 'type': 'LOCATION',
-                    'locations': [{'start': 15, 'end': 21}, {'start': 23, 'end': 30}]}
-            ],
-        'relations':
-            [
-                {'id': 'R0', 'type': 'lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T1'},
-                    {'type': 'Arg2', 'target': 'T2'}]},
-                {'id': 'R1', 'type': 'located_in', 'arguments': [{'type': 'Arg1', 'target': 'T0'},
-                    {'type': 'Arg2', 'target': 'T2'}]},
-                {'id': 'R2', 'type': 'works_at', 'arguments': [{'type': 'Arg1', 'target': 'T1'},
-                    {'type': 'Arg2', 'target': 'T0'}]}
-            ]
-    }
+    with open(ann_file, "r") as file:
+        for i, line in enumerate(file.readlines()):
+            assert line == serialized_annotations[i]
+    file.close()
 
-    """
-    spans = res["spans"]
-    assert len(spans) == 3
 
-    sorted_spans = sorted(spans, key=lambda x: x["locations"][0]["start"])
+@pytest.fixture
+def dummy_document():
+    document = TokenDocumentWithLabeledSpansAndBinaryRelations(
+        id="tmp_1",
+        tokens=(),
+    )
+    return document
 
-    spanid2span = dd()
 
-    span = sorted_spans[0]  # verify first span
-    assert span["locations"][0]["start"] == 0
-    assert span["locations"][0]["end"] == 5
-    assert span["type"] == "PERSON"
-    assert span["text"] == "Harry"
-    spanid2span[span["id"]] = span
+def test_write_with_exceptions_and_warnings(tmp_path, caplog, document, dummy_document):
+    path = str(tmp_path)
+    serializer = BratSerializer(
+        path=path,
+        entity_layer="labeled_spans",
+        relation_layer="binary_relations",
+    )
 
-    span = sorted_spans[1]  # verify second span (multispan)
-    assert span["locations"][0]["start"] == 15
-    assert span["locations"][0]["end"] == 21
-    assert span["locations"][1]["start"] == 23
-    assert span["locations"][1]["end"] == 30
-    assert span["type"] == "LOCATION"
-    assert span["text"] == "Berlin Germany"
-    spanid2span[span["id"]] = span
+    # list of empty documents
+    with pytest.raises(Exception) as e:
+        serializer(documents=[])
+    assert str(e.value) == "cannot serialize empty list of documents"
 
-    relations = res["relations"]
-    assert len(relations) == 3
+    # List of documents with type unexpected Document type
+    with pytest.raises(TypeError) as type_error:
+        serializer(documents=[dummy_document])
+    assert str(type_error.value) == (
+        "Document tmp_1 has unexpected type: <class "
+        "'pie_modules.documents.TokenDocumentWithLabeledSpansAndBinaryRelations'>. BratSerializer "
+        "can only serialize TextBasedDocuments."
+    )
 
-    sorted_relations = sorted(relations, key=lambda x: x["type"])
+    # Warning when metadata file already exists
+    metadata = serializer(documents=[document])
+    full_metadata_file_name = os.path.join(metadata["path"], metadata["metadata_file_name"])
+    serializer(documents=[document])
 
-    relation = sorted_relations[0]  # verify relation between first and second span
-    relation_type = relation["type"]
-    assert relation_type == "lives_in"
-    arg1 = spanid2span[relation["arguments"][0]["target"]]["text"]
-    arg2 = spanid2span[relation["arguments"][1]["target"]]["text"]
-    assert f"{arg1} {relation_type} {arg2}" == "Harry lives_in Berlin Germany"
+    assert caplog.records[0].levelname == "WARNING"
+    assert (
+        f"metadata file {full_metadata_file_name} already exists, it will be overwritten!\n"
+        in caplog.text
+    )
+
+
+@pytest.mark.parametrize("split", [None, "test"])
+def test_write_with_split(tmp_path, document, split):
+    path = str(tmp_path)
+    serializer = BratSerializer(
+        path=path, entity_layer="labeled_spans", relation_layer="binary_relations", split=split
+    )
+
+    metadata = serializer(documents=[document])
+    real_path = metadata["path"]
+    if split is None:
+        assert real_path == os.path.join(path)
+    elif split is not None:
+        assert real_path == os.path.join(path, split)

--- a/tests/unit/serializer/test_brat.py
+++ b/tests/unit/serializer/test_brat.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass
+from typing import TypeVar
+
+from pytorch_ie.core import Document
+
+from src.utils import get_pylogger
+
+log = get_pylogger(__name__)
+
+D = TypeVar("D", bound=Document)
+import pytest
+from pie_datasets import DatasetDict
+from pytorch_ie.annotations import BinaryRelation, LabeledSpan
+from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.documents import TextDocument
+
+from src.serializer import BratSerializer
+
+
+@dataclass
+class ExampleDocument(TextDocument):
+    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+
+@pytest.fixture
+def document():
+    document = ExampleDocument(text="Harry lives in Berlin. He works at DFKI.", id="tmp")
+    entities = [
+        LabeledSpan(start=0, end=5, label="PERSON"),
+        LabeledSpan(start=15, end=21, label="LOCATION"),
+        LabeledSpan(start=35, end=39, label="ORGANIZATION"),
+    ]
+    for ent in entities:
+        document.entities.predictions.append(ent)
+
+    relations = [
+        BinaryRelation(head=entities[0], tail=entities[1], label="lives_in"),
+        BinaryRelation(head=entities[0], tail=entities[2], label="works_at"),
+    ]
+
+    # add relations as predictions
+    for rel in relations:
+        document.relations.predictions.append(rel)
+
+    return document
+
+
+@pytest.fixture
+def document_with_multispan():
+    document = ExampleDocument(text="Harry lives in Berlin, Germany. He works at DFKI.", id="tmp")
+    entities = [
+        LabeledSpan(start=0, end=5, label="PERSON"),
+        LabeledSpan(start=15, end=21, label="LOCATION"),
+        LabeledSpan(start=23, end=30, label="LOCATION"),
+        LabeledSpan(start=44, end=48, label="ORGANIZATION"),
+    ]
+    for ent in entities:
+        document.entities.predictions.append(ent)
+
+    relations = [
+        BinaryRelation(head=entities[0], tail=entities[1], label="lives_in"),
+        BinaryRelation(head=entities[1], tail=entities[2], label="part_of_same"),
+        BinaryRelation(head=entities[0], tail=entities[3], label="works_at"),
+        # TODO: can have one or both relations below ?
+        # BinaryRelation(head=entities[3], tail=entities[1], label="located_in"),
+        # BinaryRelation(head=entities[3], tail=entities[2], label="located_in"),
+    ]
+
+    # add relations as predictions
+    for rel in relations:
+        document.relations.predictions.append(rel)
+
+    return document
+
+
+def test_save_and_load(tmp_path, document):
+    path = str(tmp_path)
+    serializer = BratSerializer(path=path)
+
+    serializer(documents=[document])
+
+    loaded_document = serializer.read_with_defaults()[0]
+    assert loaded_document.text == document.text
+
+    entities = document.entities.predictions
+    loaded_entities = loaded_document.entities.predictions
+    assert loaded_entities == entities
+
+    relations = document.relations.predictions
+    loaded_relations = loaded_document.relations.predictions
+    assert loaded_relations == relations
+
+
+def test_save_and_load_multispan(tmp_path, document_with_multispan):
+    path = str(tmp_path)
+    serializer = BratSerializer(path=path)
+
+    serializer(documents=[document_with_multispan])
+
+    loaded_document = serializer.read_with_defaults()[0]
+    assert loaded_document.text == document_with_multispan.text
+
+    entities = document_with_multispan.entities.predictions
+    loaded_entities = loaded_document.entities.predictions
+    assert loaded_entities == entities
+
+    relations = document_with_multispan.relations.predictions
+    loaded_relations = loaded_document.relations.predictions
+    assert loaded_relations == relations

--- a/tests/unit/serializer/test_brat.py
+++ b/tests/unit/serializer/test_brat.py
@@ -1,6 +1,11 @@
+import os
+from collections import defaultdict as dd
 from dataclasses import dataclass
 from typing import TypeVar
 
+from pie_datasets.builders.brat import BratDocument
+from pie_modules.document.processing import SpansViaRelationMerger
+from pytorch_ie import AnnotationLayer
 from pytorch_ie.core import Document
 
 from src.utils import get_pylogger
@@ -9,102 +14,256 @@ log = get_pylogger(__name__)
 
 D = TypeVar("D", bound=Document)
 import pytest
-from pie_datasets import DatasetDict
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TextDocument
+from pytorch_ie.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
+from pytorch_ie.core import annotation_field
+from pytorch_ie.documents import TextBasedDocument, TextDocumentWithLabeledSpansAndBinaryRelations
 
 from src.serializer import BratSerializer
 
 
+def get_location(location_string):
+    parts = location_string.split(" ")
+    assert (
+        len(parts) == 2
+    ), f"Wrong number of entries in location string. Expected 2, but found: {parts}"
+    return {"start": int(parts[0]), "end": int(parts[1])}
+
+
+def get_span_annotation(annotation_line):
+    """example input:
+
+    T1  Organization 0 4        Sony
+    """
+
+    _id, remaining, text = annotation_line.split("\t", maxsplit=2)
+    _type, locations = remaining.split(" ", maxsplit=1)
+    return {
+        "id": _id,
+        "text": text,
+        "type": _type,
+        "locations": [get_location(loc) for loc in locations.split(";")],
+    }
+
+
+def get_relation_annotation(annotation_line):
+    """example input:
+
+    R1  Origin Arg1:T3 Arg2:T4
+    """
+
+    _id, remaining = annotation_line.strip().split("\t")
+    _type, remaining = remaining.split(" ", maxsplit=1)
+    args = [dict(zip(["type", "target"], a.split(":"))) for a in remaining.split(" ")]
+    return {"id": _id, "type": _type, "arguments": args}
+
+
+def read_annotation_file(filename):
+    res = {
+        "spans": [],
+        "relations": [],
+    }
+    with open(filename, encoding="utf-8") as file:
+        for i, line in enumerate(file):
+            if len(line.strip()) == 0:
+                continue
+            ann_type = line[0]
+            # strip away the new line character
+            if line.endswith("\n"):
+                line = line[:-1]
+            if ann_type == "T":
+                res["spans"].append(get_span_annotation(line))
+            elif ann_type == "R":
+                res["relations"].append(get_relation_annotation(line))
+            else:
+                raise ValueError(
+                    f'unknown BRAT annotation id type: "{line}" (from file {filename} @line {i}). '
+                    f"Annotation ids have to start with T (spans), E (events), R (relations), "
+                    f"A (attributions), or N (normalizations). See "
+                    f"https://brat.nlplab.org/standoff.html for the BRAT annotation file "
+                    f"specification."
+                )
+    return res
+
+
 @dataclass
-class ExampleDocument(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+class TextDocumentWithLabeledMultiSpansAndBinaryRelations(TextBasedDocument):
+    labeled_spans: AnnotationLayer[LabeledMultiSpan] = annotation_field(target="text")
+    binary_relations: AnnotationLayer[BinaryRelation] = annotation_field(target="labeled_spans")
 
 
 @pytest.fixture
-def document():
-    document = ExampleDocument(text="Harry lives in Berlin. He works at DFKI.", id="tmp")
-    entities = [
+def document_processor():
+    dp = SpansViaRelationMerger(
+        relation_layer="binary_relations",
+        link_relation_label="parts_of_same",
+        result_document_type=BratDocument,
+        result_field_mapping={"labeled_spans": "spans", "binary_relations": "relations"},
+    )
+
+    return dp
+
+
+@pytest.fixture
+def document_with_gold_only():
+    document = TextDocumentWithLabeledSpansAndBinaryRelations(
+        text="Harry lives in Berlin. He works at DFKI.", id="tmp"
+    )
+    labeled_spans = [
         LabeledSpan(start=0, end=5, label="PERSON"),
         LabeledSpan(start=15, end=21, label="LOCATION"),
         LabeledSpan(start=35, end=39, label="ORGANIZATION"),
     ]
-    for ent in entities:
-        document.entities.predictions.append(ent)
+    for ent in labeled_spans:
+        document.labeled_spans.append(ent)
 
-    relations = [
-        BinaryRelation(head=entities[0], tail=entities[1], label="lives_in"),
-        BinaryRelation(head=entities[0], tail=entities[2], label="works_at"),
+    binary_relations = [
+        BinaryRelation(head=labeled_spans[0], tail=labeled_spans[1], label="lives_in"),
+        BinaryRelation(head=labeled_spans[0], tail=labeled_spans[2], label="works_at"),
     ]
 
-    # add relations as predictions
-    for rel in relations:
-        document.relations.predictions.append(rel)
+    for rel in binary_relations:
+        document.binary_relations.append(rel)
 
     return document
+
+
+def test_save_gold_only(tmp_path, document_with_gold_only, document_processor):
+    path = str(tmp_path)
+    serializer = BratSerializer(
+        path=path, document_processor=document_processor, gold_label_prefix="GOLD"
+    )
+
+    metadata = serializer(documents=[document_with_gold_only])
+
+    path = metadata["path"]
+    res = read_annotation_file(os.path.join(path, f"{document_with_gold_only.id}.ann"))
+    """
+    res in the following format:
+    {'spans':
+        [
+            {'id': 'T0', 'text': 'Harry', 'type': 'GOLD-PERSON', 'locations': [{'start': 0, 'end': 5}]},
+            {'id': 'T1', 'text': 'DFKI', 'type': 'GOLD-ORGANIZATION', 'locations': [{'start': 35, 'end': 39}]},
+            {'id': 'T2', 'text': 'Berlin', 'type': 'GOLD-LOCATION', 'locations': [{'start': 15, 'end': 21}]}
+        ],
+    'relations':
+        [
+            {'id': 'R0', 'type': 'lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T0'},
+                {'type': 'Arg2', 'target': 'T2'}]},
+            {'id': 'R1', 'type': 'works_at', 'arguments': [{'type': 'Arg1', 'target': 'T0'},
+                {'type': 'Arg2', 'target': 'T1'}]}
+        ]
+    }
+    """
+    spans = res["spans"]
+    original_spans = document_with_gold_only.labeled_spans
+    assert len(spans) == len(original_spans)
+
+    sorted_spans = sorted(spans, key=lambda x: x["locations"][0]["start"])
+    sorted_original_spans = sorted(original_spans, key=lambda x: x.start)
+    span2spanid = dd()
+    for span, original_span in zip(sorted_spans, sorted_original_spans):
+        assert span["locations"][0]["start"] == original_span.start
+        assert span["locations"][0]["end"] == original_span.end
+        assert span["type"] == f"GOLD-{original_span.label}"
+        assert (
+            span["text"] == document_with_gold_only.text[original_span.start : original_span.end]
+        )
+
+        span2spanid[original_span] = span["id"]
+
+    relations = res["relations"]
+    original_relations = document_with_gold_only.binary_relations
+    assert len(relations) == len(original_relations)
+
+    sorted_relations = sorted(relations, key=lambda x: x["type"])
+    sorted_original_relations = sorted(original_relations, key=lambda x: x.label)
+
+    for relation, original_relation in zip(sorted_relations, sorted_original_relations):
+        assert relation["type"] == original_relation.label
+        assert relation["arguments"][0]["target"] == span2spanid[original_relation.head]
+        assert relation["arguments"][1]["target"] == span2spanid[original_relation.tail]
 
 
 @pytest.fixture
-def document_with_multispan():
-    document = ExampleDocument(text="Harry lives in Berlin, Germany. He works at DFKI.", id="tmp")
-    entities = [
+def document_with_prediction_only():
+    document = TextDocumentWithLabeledSpansAndBinaryRelations(
+        text="Harry lives in Berlin. He works at DFKI.", id="tmp"
+    )
+    labeled_spans = [
         LabeledSpan(start=0, end=5, label="PERSON"),
         LabeledSpan(start=15, end=21, label="LOCATION"),
-        LabeledSpan(start=23, end=30, label="LOCATION"),
-        LabeledSpan(start=44, end=48, label="ORGANIZATION"),
+        LabeledSpan(start=35, end=39, label="ORGANIZATION"),
     ]
-    for ent in entities:
-        document.entities.predictions.append(ent)
 
-    relations = [
-        BinaryRelation(head=entities[0], tail=entities[1], label="lives_in"),
-        BinaryRelation(head=entities[1], tail=entities[2], label="part_of_same"),
-        BinaryRelation(head=entities[0], tail=entities[3], label="works_at"),
-        # TODO: can have one or both relations below ?
-        # BinaryRelation(head=entities[3], tail=entities[1], label="located_in"),
-        # BinaryRelation(head=entities[3], tail=entities[2], label="located_in"),
+    # add entities as predictions
+    for ent in labeled_spans:
+        document.labeled_spans.predictions.append(ent)
+
+    binary_relations = [
+        BinaryRelation(head=labeled_spans[0], tail=labeled_spans[1], label="lives_in"),
+        BinaryRelation(head=labeled_spans[0], tail=labeled_spans[2], label="works_at"),
     ]
 
     # add relations as predictions
-    for rel in relations:
-        document.relations.predictions.append(rel)
+    for rel in binary_relations:
+        document.binary_relations.predictions.append(rel)
 
     return document
 
 
-def test_save_and_load(tmp_path, document):
+def test_save_prediction_only(tmp_path, document_with_prediction_only, document_processor):
     path = str(tmp_path)
-    serializer = BratSerializer(path=path)
+    serializer = BratSerializer(
+        path=path, document_processor=document_processor, prediction_label_prefix="PRED"
+    )
 
-    serializer(documents=[document])
+    metadata = serializer(documents=[document_with_prediction_only])
 
-    loaded_document = serializer.read_with_defaults()[0]
-    assert loaded_document.text == document.text
+    path = metadata["path"]
+    res = read_annotation_file(os.path.join(path, f"{document_with_prediction_only.id}.ann"))
+    """
+        res in the following format:
+        {'spans':
+            [
+                {'id': 'T0', 'text': 'Harry', 'type': 'PRED-PERSON', 'locations': [{'start': 0, 'end': 5}]},
+                {'id': 'T1', 'text': 'DFKI', 'type': 'PRED-ORGANIZATION', 'locations': [{'start': 35, 'end': 39}]},
+                {'id': 'T2', 'text': 'Berlin', 'type': 'PRED-LOCATION', 'locations': [{'start': 15, 'end': 21}]}
+            ],
+        'relations':
+            [
+                {'id': 'R0', 'type': 'lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T0'},
+                    {'type': 'Arg2', 'target': 'T2'}]},
+                {'id': 'R1', 'type': 'works_at', 'arguments': [{'type': 'Arg1', 'target': 'T0'},
+                    {'type': 'Arg2', 'target': 'T1'}]}
+            ]
+        }
+        """
+    spans = res["spans"]
+    original_spans = document_with_prediction_only.labeled_spans.predictions
+    assert len(spans) == len(original_spans)
 
-    entities = document.entities.predictions
-    loaded_entities = loaded_document.entities.predictions
-    assert loaded_entities == entities
+    sorted_spans = sorted(spans, key=lambda x: x["locations"][0]["start"])
+    sorted_original_spans = sorted(original_spans, key=lambda x: x.start)
+    span2spanid = dd()
+    for span, original_span in zip(sorted_spans, sorted_original_spans):
+        assert span["locations"][0]["start"] == original_span.start
+        assert span["locations"][0]["end"] == original_span.end
+        assert span["type"] == f"PRED-{original_span.label}"
+        assert (
+            span["text"]
+            == document_with_prediction_only.text[original_span.start : original_span.end]
+        )
 
-    relations = document.relations.predictions
-    loaded_relations = loaded_document.relations.predictions
-    assert loaded_relations == relations
+        span2spanid[original_span] = span["id"]
 
+    relations = res["relations"]
+    original_relations = document_with_prediction_only.binary_relations.predictions
+    assert len(relations) == len(original_relations)
 
-def test_save_and_load_multispan(tmp_path, document_with_multispan):
-    path = str(tmp_path)
-    serializer = BratSerializer(path=path)
+    sorted_relations = sorted(relations, key=lambda x: x["type"])
+    sorted_original_relations = sorted(original_relations, key=lambda x: x.label)
 
-    serializer(documents=[document_with_multispan])
-
-    loaded_document = serializer.read_with_defaults()[0]
-    assert loaded_document.text == document_with_multispan.text
-
-    entities = document_with_multispan.entities.predictions
-    loaded_entities = loaded_document.entities.predictions
-    assert loaded_entities == entities
-
-    relations = document_with_multispan.relations.predictions
-    loaded_relations = loaded_document.relations.predictions
-    assert loaded_relations == relations
+    for relation, original_relation in zip(sorted_relations, sorted_original_relations):
+        assert relation["type"] == original_relation.label
+        assert relation["arguments"][0]["target"] == span2spanid[original_relation.head]
+        assert relation["arguments"][1]["target"] == span2spanid[original_relation.tail]

--- a/tests/unit/serializer/test_brat.py
+++ b/tests/unit/serializer/test_brat.py
@@ -33,12 +33,11 @@ def test_serialize_labeled_span():
         ]
     )
     labeled_span = document.labeled_spans[0]
-    annotation_id, serialized_annotation = serialize_annotation(
-        idx=1,
+    annotation_type, serialized_annotation = serialize_annotation(
         annotation=labeled_span,
         annotation2id={},
     )
-    assert annotation_id == "T1"
+    assert annotation_type == "T"
     assert serialized_annotation == "LOCATION 15 30\tBerlin, Germany\n"
 
 
@@ -59,12 +58,11 @@ def test_serialize_labeled_multi_span():
         ]
     )
     labeled_multi_span = document.labeled_multi_spans[0]
-    annotation_id, serialized_annotation = serialize_annotation(
-        idx=2,
+    annotation_type, serialized_annotation = serialize_annotation(
         annotation=labeled_multi_span,
         annotation2id={},
     )
-    assert annotation_id == "T2"
+    assert annotation_type == "T"
     assert serialized_annotation == "LOCATION 15 21;23 30\tBerlin Germany\n"
 
 
@@ -75,19 +73,18 @@ def test_serialize_binary_relation():
         label="lives_in",
     )
     span2id = {binary_relation.head: "T1", binary_relation.tail: "T2"}
-    annotation_id, serialized_binary_relation = serialize_binary_relation(
-        idx=1,
+    annotation_type, serialized_binary_relation = serialize_binary_relation(
         annotation=binary_relation,
         annotation2id=span2id,
     )
-    assert annotation_id == "R1"
+    assert annotation_type == "R"
     assert serialized_binary_relation == "lives_in Arg1:T1 Arg2:T2\n"
 
 
 def test_serialize_unknown_annotation():
 
     with pytest.raises(Warning) as w:
-        serialize_annotation(idx=0, annotation=Annotation(), annotation2id={})
+        serialize_annotation(annotation=Annotation(), annotation2id={})
     assert (
         str(w.value)
         == "annotation has unknown type: <class 'pytorch_ie.core.document.Annotation'>"

--- a/tests/unit/serializer/test_brat.py
+++ b/tests/unit/serializer/test_brat.py
@@ -108,31 +108,39 @@ def document():
     document = TextDocumentWithLabeledSpansAndBinaryRelations(
         text="Harry lives in Berlin. He works at DFKI.", id="tmp_1"
     )
-    predicted_labeled_spans = [
-        LabeledSpan(start=0, end=5, label="PERSON"),  # Harry
-        LabeledSpan(start=15, end=21, label="LOCATION"),  # Berlin
-    ]
-    document.labeled_spans.predictions.extend(predicted_labeled_spans)
 
-    labeled_spans = [
-        LabeledSpan(start=0, end=5, label="PERSON"),  # Harry
-        LabeledSpan(start=15, end=21, label="LOCATION"),  # Berlin
-        LabeledSpan(start=35, end=39, label="ORGANIZATION"),  # DFKI
-    ]
+    document.labeled_spans.predictions.extend(
+        [
+            LabeledSpan(start=0, end=5, label="PERSON"),  # Harry
+            LabeledSpan(start=15, end=21, label="LOCATION"),  # Berlin
+        ]
+    )
 
-    document.labeled_spans.extend(labeled_spans)
+    document.labeled_spans.extend(
+        [
+            LabeledSpan(start=0, end=5, label="PERSON"),  # Harry
+            LabeledSpan(start=15, end=21, label="LOCATION"),  # Berlin
+            LabeledSpan(start=35, end=39, label="ORGANIZATION"),  # DFKI
+        ]
+    )
 
-    predicted_binary_relations = [
-        BinaryRelation(head=labeled_spans[0], tail=labeled_spans[1], label="lives_in"),
-    ]
-    document.binary_relations.predictions.extend(predicted_binary_relations)
-
-    binary_relations = [
-        BinaryRelation(head=labeled_spans[0], tail=labeled_spans[1], label="lives_in"),
-        BinaryRelation(head=labeled_spans[0], tail=labeled_spans[2], label="works_at"),
-    ]
-
-    document.binary_relations.extend(binary_relations)
+    document.binary_relations.predictions.extend(
+        [
+            BinaryRelation(
+                head=document.labeled_spans[0], tail=document.labeled_spans[1], label="lives_in"
+            ),
+        ]
+    )
+    document.binary_relations.extend(
+        [
+            BinaryRelation(
+                head=document.labeled_spans[0], tail=document.labeled_spans[1], label="lives_in"
+            ),
+            BinaryRelation(
+                head=document.labeled_spans[0], tail=document.labeled_spans[2], label="works_at"
+            ),
+        ]
+    )
 
     return document
 
@@ -362,35 +370,50 @@ def document_with_multispan():
     document = TextDocumentWithLabeledSpansAndBinaryRelations(
         text="Harry lives in Berlin, Germany. He works at DFKI.", id="tmp"
     )
-    entities = [
-        LabeledSpan(start=0, end=5, label="PERSON"),
-        LabeledSpan(start=15, end=21, label="LOCATION"),
-        LabeledSpan(start=23, end=30, label="LOCATION"),
-        LabeledSpan(start=44, end=48, label="ORGANIZATION"),
-    ]
-    for ent in entities:
-        document.labeled_spans.predictions.append(ent)
-
-    relations = [
-        BinaryRelation(head=entities[0], tail=entities[1], label="lives_in"),
-        BinaryRelation(
-            head=entities[1], tail=entities[2], label="parts_of_same"
-        ),  # should be removed
-        BinaryRelation(
-            head=entities[1], tail=entities[3], label="parts_of_same"
-        ),  # should be removed
-        BinaryRelation(head=entities[0], tail=entities[3], label="works_at"),
-        BinaryRelation(
-            head=entities[3], tail=entities[1], label="located_in"
-        ),  # tail should be a new merged entity
-        BinaryRelation(
-            head=entities[3], tail=entities[2], label="located_in"
-        ),  # tail should be a new merged entity
-    ]
-
+    document.labeled_spans.predictions.extend(
+        [
+            LabeledSpan(start=0, end=5, label="PERSON"),
+            LabeledSpan(start=15, end=21, label="LOCATION"),
+            LabeledSpan(start=23, end=30, label="LOCATION"),
+            LabeledSpan(start=44, end=48, label="ORGANIZATION"),
+        ]
+    )
     # add relations as predictions
-    for rel in relations:
-        document.binary_relations.predictions.append(rel)
+
+    document.binary_relations.predictions.extend(
+        [
+            BinaryRelation(
+                head=document.labeled_spans.predictions[0],
+                tail=document.labeled_spans.predictions[1],
+                label="lives_in",
+            ),
+            BinaryRelation(
+                head=document.labeled_spans.predictions[1],
+                tail=document.labeled_spans.predictions[2],
+                label="parts_of_same",
+            ),  # should be removed
+            BinaryRelation(
+                head=document.labeled_spans.predictions[1],
+                tail=document.labeled_spans.predictions[3],
+                label="parts_of_same",
+            ),  # should be removed
+            BinaryRelation(
+                head=document.labeled_spans.predictions[0],
+                tail=document.labeled_spans.predictions[3],
+                label="works_at",
+            ),
+            BinaryRelation(
+                head=document.labeled_spans.predictions[3],
+                tail=document.labeled_spans.predictions[1],
+                label="located_in",
+            ),  # tail should be a new merged entity
+            BinaryRelation(
+                head=document.labeled_spans.predictions[3],
+                tail=document.labeled_spans.predictions[2],
+                label="located_in",
+            ),  # tail should be a new merged entity
+        ]
+    )
 
     return document
 

--- a/tests/unit/serializer/test_brat.py
+++ b/tests/unit/serializer/test_brat.py
@@ -104,130 +104,59 @@ def document_processor():
 
 
 @pytest.fixture
-def document_with_gold_only():
+def document():
     document = TextDocumentWithLabeledSpansAndBinaryRelations(
-        text="Harry lives in Berlin. He works at DFKI.", id="tmp"
+        text="Harry lives in Berlin. He works at DFKI.", id="tmp_1"
     )
-    labeled_spans = [
-        LabeledSpan(start=0, end=5, label="PERSON"),
-        LabeledSpan(start=15, end=21, label="LOCATION"),
-        LabeledSpan(start=35, end=39, label="ORGANIZATION"),
+    predicted_labeled_spans = [
+        LabeledSpan(start=0, end=5, label="PERSON"),  # Harry
+        LabeledSpan(start=15, end=21, label="LOCATION"),  # Berlin
     ]
-    for ent in labeled_spans:
-        document.labeled_spans.append(ent)
+    document.labeled_spans.predictions.extend(predicted_labeled_spans)
+
+    labeled_spans = [
+        LabeledSpan(start=0, end=5, label="PERSON"),  # Harry
+        LabeledSpan(start=15, end=21, label="LOCATION"),  # Berlin
+        LabeledSpan(start=35, end=39, label="ORGANIZATION"),  # DFKI
+    ]
+
+    document.labeled_spans.extend(labeled_spans)
+
+    predicted_binary_relations = [
+        BinaryRelation(head=labeled_spans[0], tail=labeled_spans[1], label="lives_in"),
+    ]
+    document.binary_relations.predictions.extend(predicted_binary_relations)
 
     binary_relations = [
         BinaryRelation(head=labeled_spans[0], tail=labeled_spans[1], label="lives_in"),
         BinaryRelation(head=labeled_spans[0], tail=labeled_spans[2], label="works_at"),
     ]
 
-    for rel in binary_relations:
-        document.binary_relations.append(rel)
+    document.binary_relations.extend(binary_relations)
 
     return document
 
 
-def test_save_gold_only(tmp_path, document_with_gold_only, document_processor):
+def test_save(tmp_path, document, document_processor):
     path = str(tmp_path)
     serializer = BratSerializer(
-        path=path, document_processor=document_processor, gold_label_prefix="GOLD"
+        path=path,
+        document_processor=document_processor,
+        entity_layer="spans",
+        relation_layer="relations",
     )
 
-    metadata = serializer(documents=[document_with_gold_only])
+    metadata = serializer(documents=[document])
 
     path = metadata["path"]
-    res = read_annotation_file(os.path.join(path, f"{document_with_gold_only.id}.ann"))
-    """
-    res in the following format:
-    {'spans':
-        [
-            {'id': 'T0', 'text': 'Harry', 'type': 'GOLD-PERSON', 'locations': [{'start': 0, 'end': 5}]},
-            {'id': 'T1', 'text': 'DFKI', 'type': 'GOLD-ORGANIZATION', 'locations': [{'start': 35, 'end': 39}]},
-            {'id': 'T2', 'text': 'Berlin', 'type': 'GOLD-LOCATION', 'locations': [{'start': 15, 'end': 21}]}
-        ],
-    'relations':
-        [
-            {'id': 'R0', 'type': 'lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T0'},
-                {'type': 'Arg2', 'target': 'T2'}]},
-            {'id': 'R1', 'type': 'works_at', 'arguments': [{'type': 'Arg1', 'target': 'T0'},
-                {'type': 'Arg2', 'target': 'T1'}]}
-        ]
-    }
-    """
-    spans = res["spans"]
-    original_spans = document_with_gold_only.labeled_spans
-    assert len(spans) == len(original_spans)
-
-    sorted_spans = sorted(spans, key=lambda x: x["locations"][0]["start"])
-    sorted_original_spans = sorted(original_spans, key=lambda x: x.start)
-    span2spanid = dd()
-    for span, original_span in zip(sorted_spans, sorted_original_spans):
-        assert span["locations"][0]["start"] == original_span.start
-        assert span["locations"][0]["end"] == original_span.end
-        assert span["type"] == f"GOLD-{original_span.label}"
-        assert (
-            span["text"] == document_with_gold_only.text[original_span.start : original_span.end]
-        )
-
-        span2spanid[original_span] = span["id"]
-
-    relations = res["relations"]
-    original_relations = document_with_gold_only.binary_relations
-    assert len(relations) == len(original_relations)
-
-    sorted_relations = sorted(relations, key=lambda x: x["type"])
-    sorted_original_relations = sorted(original_relations, key=lambda x: x.label)
-
-    for relation, original_relation in zip(sorted_relations, sorted_original_relations):
-        assert relation["type"] == original_relation.label
-        assert relation["arguments"][0]["target"] == span2spanid[original_relation.head]
-        assert relation["arguments"][1]["target"] == span2spanid[original_relation.tail]
-
-
-@pytest.fixture
-def document_with_prediction_only():
-    document = TextDocumentWithLabeledSpansAndBinaryRelations(
-        text="Harry lives in Berlin. He works at DFKI.", id="tmp"
-    )
-    labeled_spans = [
-        LabeledSpan(start=0, end=5, label="PERSON"),
-        LabeledSpan(start=15, end=21, label="LOCATION"),
-        LabeledSpan(start=35, end=39, label="ORGANIZATION"),
-    ]
-
-    # add entities as predictions
-    for ent in labeled_spans:
-        document.labeled_spans.predictions.append(ent)
-
-    binary_relations = [
-        BinaryRelation(head=labeled_spans[0], tail=labeled_spans[1], label="lives_in"),
-        BinaryRelation(head=labeled_spans[0], tail=labeled_spans[2], label="works_at"),
-    ]
-
-    # add relations as predictions
-    for rel in binary_relations:
-        document.binary_relations.predictions.append(rel)
-
-    return document
-
-
-def test_save_prediction_only(tmp_path, document_with_prediction_only, document_processor):
-    path = str(tmp_path)
-    serializer = BratSerializer(
-        path=path, document_processor=document_processor, prediction_label_prefix="PRED"
-    )
-
-    metadata = serializer(documents=[document_with_prediction_only])
-
-    path = metadata["path"]
-    res = read_annotation_file(os.path.join(path, f"{document_with_prediction_only.id}.ann"))
+    res = read_annotation_file(os.path.join(path, f"{document.id}.ann"))
     """
         res in the following format:
         {'spans':
             [
-                {'id': 'T0', 'text': 'Harry', 'type': 'PRED-PERSON', 'locations': [{'start': 0, 'end': 5}]},
-                {'id': 'T1', 'text': 'DFKI', 'type': 'PRED-ORGANIZATION', 'locations': [{'start': 35, 'end': 39}]},
-                {'id': 'T2', 'text': 'Berlin', 'type': 'PRED-LOCATION', 'locations': [{'start': 15, 'end': 21}]}
+                {'id': 'T0', 'text': 'Harry', 'type': 'PERSON', 'locations': [{'start': 0, 'end': 5}]},
+                {'id': 'T1', 'text': 'DFKI', 'type': 'ORGANIZATION', 'locations': [{'start': 35, 'end': 39}]},
+                {'id': 'T2', 'text': 'Berlin', 'type': 'LOCATION', 'locations': [{'start': 15, 'end': 21}]}
             ],
         'relations':
             [
@@ -239,31 +168,299 @@ def test_save_prediction_only(tmp_path, document_with_prediction_only, document_
         }
         """
     spans = res["spans"]
-    original_spans = document_with_prediction_only.labeled_spans.predictions
+    original_spans = document.labeled_spans.predictions
     assert len(spans) == len(original_spans)
 
-    sorted_spans = sorted(spans, key=lambda x: x["locations"][0]["start"])
-    sorted_original_spans = sorted(original_spans, key=lambda x: x.start)
-    span2spanid = dd()
+    sorted_spans = sorted(
+        spans, key=lambda x: x["locations"][0]["start"]
+    )  # sort by start index of first span
+    sorted_original_spans = sorted(original_spans, key=lambda x: x.start)  # sort by start index
+    spanid2span = dd()  # map span_id (T0,T1,..) to original span
     for span, original_span in zip(sorted_spans, sorted_original_spans):
         assert span["locations"][0]["start"] == original_span.start
         assert span["locations"][0]["end"] == original_span.end
-        assert span["type"] == f"PRED-{original_span.label}"
-        assert (
-            span["text"]
-            == document_with_prediction_only.text[original_span.start : original_span.end]
-        )
+        assert span["type"] == original_span.label
+        assert span["text"] == document.text[original_span.start : original_span.end]
 
-        span2spanid[original_span] = span["id"]
+        spanid2span[span["id"]] = original_span
 
     relations = res["relations"]
-    original_relations = document_with_prediction_only.binary_relations.predictions
+    original_relations = document.binary_relations.predictions
     assert len(relations) == len(original_relations)
 
-    sorted_relations = sorted(relations, key=lambda x: x["type"])
+    sorted_relations = sorted(relations, key=lambda x: x["type"])  # sort by relation label
     sorted_original_relations = sorted(original_relations, key=lambda x: x.label)
 
     for relation, original_relation in zip(sorted_relations, sorted_original_relations):
         assert relation["type"] == original_relation.label
-        assert relation["arguments"][0]["target"] == span2spanid[original_relation.head]
-        assert relation["arguments"][1]["target"] == span2spanid[original_relation.tail]
+        assert spanid2span[relation["arguments"][0]["target"]] == original_relation.head
+        assert spanid2span[relation["arguments"][1]["target"]] == original_relation.tail
+
+
+def test_save_gold_annotation_with_prefix(tmp_path, document, document_processor):
+    path = str(tmp_path)
+    serializer = BratSerializer(
+        path=path,
+        document_processor=document_processor,
+        entity_layer="spans",
+        relation_layer="relations",
+        gold_label_prefix="GOLD",
+    )
+
+    metadata = serializer(documents=[document])
+
+    path = metadata["path"]
+    res = read_annotation_file(os.path.join(path, f"{document.id}.ann"))
+    """
+    res in the following format:
+    {
+        'spans':
+            [
+                {'id': 'T0', 'text': 'Berlin', 'type': 'GOLD-LOCATION', 'locations': [{'start': 15, 'end': 21}]},
+                {'id': 'T1', 'text': 'Harry', 'type': 'GOLD-PERSON', 'locations': [{'start': 0, 'end': 5}]},
+                {'id': 'T2', 'text': 'DFKI', 'type': 'GOLD-ORGANIZATION', 'locations': [{'start': 35, 'end': 39}]},
+                {'id': 'T3', 'text': 'Berlin', 'type': 'LOCATION', 'locations': [{'start': 15, 'end': 21}]},
+                {'id': 'T4', 'text': 'Harry', 'type': 'PERSON', 'locations': [{'start': 0, 'end': 5}]}
+            ],
+        'relations':
+            [
+                {'id': 'R0', 'type': 'GOLD-lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T1'},
+                    {'type': 'Arg2', 'target': 'T0'}]},
+                {'id': 'R1', 'type': 'GOLD-works_at', 'arguments': [{'type': 'Arg1', 'target': 'T1'},
+                    {'type': 'Arg2', 'target': 'T2'}]},
+                {'id': 'R3', 'type': 'lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T4'},
+                    {'type': 'Arg2', 'target': 'T3'}]}
+            ]
+    }
+
+    """
+    spans = res["spans"]
+    sorted_spans = sorted(spans, key=lambda x: x["type"])[
+        :3
+    ]  # only first three are gold annotations
+    original_spans = document.labeled_spans
+    sorted_original_spans = sorted(original_spans, key=lambda x: x.label)
+    assert len(sorted_spans) == len(sorted_original_spans)
+
+    spanid2span = dd()
+    for span, original_span in zip(sorted_spans, sorted_original_spans):
+        assert span["locations"][0]["start"] == original_span.start
+        assert span["locations"][0]["end"] == original_span.end
+        assert span["type"] == f"GOLD-{original_span.label}"
+        assert span["text"] == document.text[original_span.start : original_span.end]
+
+        spanid2span[span["id"]] = original_span
+
+    relations = res["relations"]
+    sorted_relations = sorted(relations, key=lambda x: x["type"])[
+        :2
+    ]  # only first two are gold annotations
+    original_relations = document.binary_relations
+    sorted_original_relations = sorted(original_relations, key=lambda x: x.label)
+    assert len(sorted_relations) == len(sorted_original_relations)
+
+    for relation, original_relation in zip(sorted_relations, sorted_original_relations):
+        assert relation["type"] == f"GOLD-{original_relation.label}"
+        assert spanid2span[relation["arguments"][0]["target"]] == original_relation.head
+        assert spanid2span[relation["arguments"][1]["target"]] == original_relation.tail
+
+
+def test_save_gold_and_predicted_annotation_with_prefix(tmp_path, document, document_processor):
+    path = str(tmp_path)
+    serializer = BratSerializer(
+        path=path,
+        document_processor=document_processor,
+        entity_layer="spans",
+        relation_layer="relations",
+        gold_label_prefix="GOLD",
+        prediction_label_prefix="PRED",
+    )
+
+    metadata = serializer(documents=[document])
+
+    path = metadata["path"]
+    res = read_annotation_file(os.path.join(path, f"{document.id}.ann"))
+    """
+    res in the following format:
+    {
+        'spans':
+            [
+                {'id': 'T0', 'text': 'Berlin', 'type': 'GOLD-LOCATION', 'locations': [{'start': 15, 'end': 21}]},
+                {'id': 'T1', 'text': 'Harry', 'type': 'GOLD-PERSON', 'locations': [{'start': 0, 'end': 5}]},
+                {'id': 'T2', 'text': 'DFKI', 'type': 'GOLD-ORGANIZATION', 'locations': [{'start': 35, 'end': 39}]},
+                {'id': 'T3', 'text': 'Berlin', 'type': 'PRED-LOCATION', 'locations': [{'start': 15, 'end': 21}]},
+                {'id': 'T4', 'text': 'Harry', 'type': 'PRED-PERSON', 'locations': [{'start': 0, 'end': 5}]}
+            ],
+        'relations':
+            [
+                {'id': 'R0', 'type': 'GOLD-lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T1'},
+                    {'type': 'Arg2', 'target': 'T0'}]},
+                {'id': 'R1', 'type': 'GOLD-works_at', 'arguments': [{'type': 'Arg1', 'target': 'T1'},
+                    {'type': 'Arg2', 'target': 'T2'}]},
+                {'id': 'R3', 'type': 'PRED-lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T4'},
+                    {'type': 'Arg2', 'target': 'T3'}]}
+            ]
+    }
+
+    """
+    spans = res["spans"]
+    sorted_spans = sorted(spans, key=lambda x: x["type"])
+
+    gold_spans = sorted_spans[:3]  # only first three are gold annotations
+    original_gold_spans = document.labeled_spans
+    sorted_original_gold_spans = sorted(original_gold_spans, key=lambda x: x.label)
+    assert len(gold_spans) == len(sorted_original_gold_spans)
+
+    spanid2span = dd()
+    for span, original_span in zip(gold_spans, sorted_original_gold_spans):
+        assert span["locations"][0]["start"] == original_span.start
+        assert span["locations"][0]["end"] == original_span.end
+        assert span["type"] == f"GOLD-{original_span.label}"
+        assert span["text"] == document.text[original_span.start : original_span.end]
+
+        spanid2span[span["id"]] = original_span
+
+    predicted_spans = sorted_spans[3:]  # last two are predicted annotations
+    original_predicted_spans = document.labeled_spans.predictions
+    sorted_original_predicted_spans = sorted(original_predicted_spans, key=lambda x: x.label)
+    assert len(predicted_spans) == len(sorted_original_predicted_spans)
+
+    for span, original_span in zip(predicted_spans, sorted_original_predicted_spans):
+        assert span["locations"][0]["start"] == original_span.start
+        assert span["locations"][0]["end"] == original_span.end
+        assert span["type"] == f"PRED-{original_span.label}"
+        assert span["text"] == document.text[original_span.start : original_span.end]
+
+        spanid2span[span["id"]] = original_span
+
+    relations = res["relations"]
+    sorted_relations = sorted(relations, key=lambda x: x["type"])
+
+    gold_relations = sorted_relations[:2]  # only first two are gold annotations
+    original_gold_relations = document.binary_relations
+    sorted_original_relations = sorted(original_gold_relations, key=lambda x: x.label)
+    assert len(gold_relations) == len(sorted_original_relations)
+
+    for relation, original_relation in zip(gold_relations, sorted_original_relations):
+        assert relation["type"] == f"GOLD-{original_relation.label}"
+        assert spanid2span[relation["arguments"][0]["target"]] == original_relation.head
+        assert spanid2span[relation["arguments"][1]["target"]] == original_relation.tail
+
+    predicted_relations = sorted_relations[2:]  # only last annotation is predicted annotation
+    original_predicted_relations = document.binary_relations.predictions
+    sorted_original_relations = sorted(original_predicted_relations, key=lambda x: x.label)
+    assert len(predicted_relations) == len(sorted_original_relations)
+
+    for relation, original_relation in zip(predicted_relations, sorted_original_relations):
+        assert relation["type"] == f"PRED-{original_relation.label}"
+        assert spanid2span[relation["arguments"][0]["target"]] == original_relation.head
+        assert spanid2span[relation["arguments"][1]["target"]] == original_relation.tail
+
+
+@pytest.fixture
+def document_with_multispan():
+    document = TextDocumentWithLabeledSpansAndBinaryRelations(
+        text="Harry lives in Berlin, Germany. He works at DFKI.", id="tmp"
+    )
+    entities = [
+        LabeledSpan(start=0, end=5, label="PERSON"),
+        LabeledSpan(start=15, end=21, label="LOCATION"),
+        LabeledSpan(start=23, end=30, label="LOCATION"),
+        LabeledSpan(start=44, end=48, label="ORGANIZATION"),
+    ]
+    for ent in entities:
+        document.labeled_spans.predictions.append(ent)
+
+    relations = [
+        BinaryRelation(head=entities[0], tail=entities[1], label="lives_in"),
+        BinaryRelation(
+            head=entities[1], tail=entities[2], label="parts_of_same"
+        ),  # should be removed
+        BinaryRelation(
+            head=entities[1], tail=entities[3], label="parts_of_same"
+        ),  # should be removed
+        BinaryRelation(head=entities[0], tail=entities[3], label="works_at"),
+        BinaryRelation(
+            head=entities[3], tail=entities[1], label="located_in"
+        ),  # tail should be a new merged entity
+        BinaryRelation(
+            head=entities[3], tail=entities[2], label="located_in"
+        ),  # tail should be a new merged entity
+    ]
+
+    # add relations as predictions
+    for rel in relations:
+        document.binary_relations.predictions.append(rel)
+
+    return document
+
+
+def test_save_multispan(tmp_path, document_with_multispan, document_processor):
+    path = str(tmp_path)
+    serializer = BratSerializer(
+        path=path,
+        document_processor=document_processor,
+        entity_layer="spans",
+        relation_layer="relations",
+    )
+
+    metadata = serializer(documents=[document_with_multispan])
+
+    path = metadata["path"]
+    res = read_annotation_file(os.path.join(path, f"{document_with_multispan.id}.ann"))
+
+    """
+    {
+        'spans':
+            [
+                {'id': 'T0', 'text': 'DFKI', 'type': 'ORGANIZATION', 'locations': [{'start': 44, 'end': 48}]},
+                {'id': 'T1', 'text': 'Harry', 'type': 'PERSON', 'locations': [{'start': 0, 'end': 5}]},
+                {'id': 'T2', 'text': 'Berlin Germany', 'type': 'LOCATION',
+                    'locations': [{'start': 15, 'end': 21}, {'start': 23, 'end': 30}]}
+            ],
+        'relations':
+            [
+                {'id': 'R0', 'type': 'lives_in', 'arguments': [{'type': 'Arg1', 'target': 'T1'},
+                    {'type': 'Arg2', 'target': 'T2'}]},
+                {'id': 'R1', 'type': 'located_in', 'arguments': [{'type': 'Arg1', 'target': 'T0'},
+                    {'type': 'Arg2', 'target': 'T2'}]},
+                {'id': 'R2', 'type': 'works_at', 'arguments': [{'type': 'Arg1', 'target': 'T1'},
+                    {'type': 'Arg2', 'target': 'T0'}]}
+            ]
+    }
+
+    """
+    spans = res["spans"]
+    assert len(spans) == 3
+
+    sorted_spans = sorted(spans, key=lambda x: x["locations"][0]["start"])
+
+    spanid2span = dd()
+
+    span = sorted_spans[0]  # verify first span
+    assert span["locations"][0]["start"] == 0
+    assert span["locations"][0]["end"] == 5
+    assert span["type"] == "PERSON"
+    assert span["text"] == "Harry"
+    spanid2span[span["id"]] = span
+
+    span = sorted_spans[1]  # verify second span (multispan)
+    assert span["locations"][0]["start"] == 15
+    assert span["locations"][0]["end"] == 21
+    assert span["locations"][1]["start"] == 23
+    assert span["locations"][1]["end"] == 30
+    assert span["type"] == "LOCATION"
+    assert span["text"] == "Berlin Germany"
+    spanid2span[span["id"]] = span
+
+    relations = res["relations"]
+    assert len(relations) == 3
+
+    sorted_relations = sorted(relations, key=lambda x: x["type"])
+
+    relation = sorted_relations[0]  # verify relation between first and second span
+    relation_type = relation["type"]
+    assert relation_type == "lives_in"
+    arg1 = spanid2span[relation["arguments"][0]["target"]]["text"]
+    arg2 = spanid2span[relation["arguments"][1]["target"]]["text"]
+    assert f"{arg1} {relation_type} {arg2}" == "Harry lives_in Berlin Germany"

--- a/tests/unit/serializer/test_brat.py
+++ b/tests/unit/serializer/test_brat.py
@@ -68,16 +68,6 @@ def test_serialize_labeled_multi_span():
     assert serialized_annotation == "LOCATION 15 21;23 30\tBerlin Germany\n"
 
 
-def test_serialize_unknown_annotation():
-
-    with pytest.raises(Warning) as w:
-        serialize_annotation(idx=0, annotation=Annotation(), annotation2id={})
-    assert (
-        str(w.value)
-        == "annotation has unknown type: <class 'pytorch_ie.core.document.Annotation'>"
-    )
-
-
 def test_serialize_binary_relation():
     binary_relation = BinaryRelation(
         head=LabeledSpan(start=0, end=5, label="PERSON"),
@@ -93,10 +83,15 @@ def test_serialize_binary_relation():
     assert annotation_id == "R1"
     assert serialized_binary_relation == "lives_in Arg1:T1 Arg2:T2\n"
 
-    # Unknown relation type
+
+def test_serialize_unknown_annotation():
+
     with pytest.raises(Warning) as w:
-        serialize_binary_relation(idx=0, annotation=None, annotation2id={})
-    assert str(w.value) == "relation has unknown type: <class 'NoneType'>"
+        serialize_annotation(idx=0, annotation=Annotation(), annotation2id={})
+    assert (
+        str(w.value)
+        == "annotation has unknown type: <class 'pytorch_ie.core.document.Annotation'>"
+    )
 
 
 @dataclass


### PR DESCRIPTION
This adds Brat Serializer which writes model predictions to annotation files (.ann) in Brat format. It requires a `layers` parameter to specify the annotation layers to serialize. For now, it supports layers containing _LabeledSpan_, _LabeledMultiSpan_, and _BinaryRelation_ annotations. If a `gold_label_prefix` is provided, the gold annotations are serialized with the given prefix.  Otherwise, only the predicted annotations are serialized. A `document_processor` can be provided to process documents before serialization.

### Usage

```python
from src.serializer import BratSerializer
from pie_modules.annotations import BinaryRelation, LabeledSpan
from pie_modules.documents import TextDocumentWithLabeledSpansAndBinaryRelations

# create an example document
document = TextDocumentWithLabeledSpansAndBinaryRelations(
        text="Harry lives in Berlin. He works at DFKI.", id="tmp_1"
)
# create annotations
harry = LabeledSpan(start=0, end=5, label="PERSON")  # Harry
berlin = LabeledSpan(start=15, end=21, label="LOCATION")  # Berlin
# add annotations to the document
document.labeled_spans.predictions.extend([harry, berlin])
document.binary_relations.predictions.append(BinaryRelation(head=harry,tail=berlin,label="lives_in"))

serializer = BratSerializer(path='/tmp', layers=["labeled_spans","binary_relations"])
metadata = serializer(documents=[document])

"""
Saved at os.path.join(metadata['path'], f"{document.id}.ann") with following content

T0      LOCATION 15 21  Berlin
T1      PERSON 0 5      Harry
R0      lives_in Arg1:T1 Arg2:T0
"""
```

**Note: This PR updates pie-modules to v0.10.6** with fixed `LabeledMultiSpan` (see [here](https://github.com/ArneBinder/pie-modules/pull/59))