### PR TITLE
fix: add dependency for relation argument distance metric configs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # --------- pytorch-ie --------- #
 pytorch-ie>=0.28.0,<0.30.0
 pie-datasets>=0.8.1,<0.9.0
-pie-modules>=0.10.8,<0.11.0
+pie-modules>=0.10.9,<0.11.0
 
 # --------- hydra --------- #
 hydra-core>=1.3.0


### PR DESCRIPTION
This was missed in #158.