### PR TITLE
functionality to use pretrained pie model

### DIFF
--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -61,6 +61,9 @@ monitor_mode: "max"
 # seed for random number generators in pytorch, numpy and python.random
 seed: null
 
+# path to pretrained pytorch-ie model that updates the weights of base model with pretrained pie model
+pretrained_pie_model_path: null
+
 # simply provide checkpoint path to resume training
 ckpt_path: null
 


### PR DESCRIPTION
This PR adds functionality to use a pretrained PyTorch-IE model that allows updating weights of base transformer model. Additionally, it provides an optional parameter, `pretrained_pie_model_prefix_mapping`, to filter and specify which model layers should be updated.

Usage:

```bash
python src/train.py experiment=conll2003 pretrained_pie_model_path=path/to/pretrained/pie/model "+pretrained_pie_model_prefix_mapping={model.model:model.model}"

```