### PR TITLE
brat serializer: allow using annotation ids from document metadata

### DIFF
--- a/src/serializer/brat.py
+++ b/src/serializer/brat.py
@@ -113,20 +113,29 @@ def serialize_annotations(
     indices: Dict[str, int],
     annotation2id: Dict[Annotation, str],
     label_prefix: Optional[str] = None,
+    annotation_ids: Optional[List[str]] = None,
 ) -> Tuple[List[str], Dict[Annotation, str]]:
     serialized_annotations = []
     new_annotation2id: Dict[Annotation, str] = {}
-    for annotation in annotations:
+    for idx, annotation in enumerate(annotations):
         annotation_type, serialized_annotation = serialize_annotation(
             annotation=annotation,
             annotation2id=annotation2id,
             label_prefix=label_prefix,
         )
-        idx = indices[annotation_type]
-        annotation_id = f"{annotation_type}{idx}"
+        if annotation_ids is not None:
+            if indices.get(annotation_type, 0) > 0:
+                raise ValueError(
+                    "Cannot specify annotation IDs for the same type (e.g. T or R) if there are "
+                    "other annotations of the same type without an ID."
+                )
+            annotation_id = annotation_ids[idx]
+        else:
+            index = indices[annotation_type]
+            annotation_id = f"{annotation_type}{index}"
+            indices[annotation_type] += 1
         serialized_annotations.append(f"{annotation_id}\t{serialized_annotation}")
         new_annotation2id[annotation] = annotation_id
-        indices[annotation_type] += 1
 
     return serialized_annotations, new_annotation2id
 
@@ -135,6 +144,8 @@ def serialize_annotation_layers(
     layers: List[Tuple[AnnotationLayer, str]],
     gold_label_prefix: Optional[str] = None,
     prediction_label_prefix: Optional[str] = None,
+    gold_annotation_ids: Optional[List[Optional[List[str]]]] = None,
+    prediction_annotation_ids: Optional[List[Optional[List[str]]]] = None,
 ) -> List[str]:
     """Serialize annotations from given annotation layers into a list of strings.
 
@@ -145,15 +156,20 @@ def serialize_annotation_layers(
             Defaults to None.
         prediction_label_prefix (Optional[str], optional): Prefix to be added to prediction labels.
             Defaults to None.
+        gold_annotation_ids (Optional[List[Optional[str]]], optional): List of gold annotation IDs.
+            If provided, the length should match the number of layers. Defaults to None.
+        prediction_annotation_ids (Optional[List[Optional[str]]], optional): List of prediction
+            annotation IDs. If provided, the length should match the number of layers. Defaults to None.
 
     Returns:
         List[str]: List of serialized annotations.
     """
+
     all_serialized_annotations = []
     gold_annotation2id: Dict[Annotation, str] = {}
     prediction_annotation2id: Dict[Annotation, str] = {}
     indices: Dict[str, int] = defaultdict(int)
-    for layer, what in layers:
+    for idx, (layer, what) in enumerate(layers):
         if what not in ["gold", "prediction", "both"]:
             raise ValueError(
                 f'Invalid value for what to serialize: "{what}". Expected "gold", "prediction", or "both".'
@@ -171,16 +187,46 @@ def serialize_annotation_layers(
             )
         serialized_annotations = []
         if what in ["gold", "both"]:
+            if gold_annotation_ids is not None:
+                if len(gold_annotation_ids) <= idx:
+                    raise ValueError(
+                        "gold_annotation_ids should have the same length as the number of layers."
+                    )
+                current_gold_annotation_ids = gold_annotation_ids[idx]
+                if current_gold_annotation_ids is not None and len(
+                    current_gold_annotation_ids
+                ) != len(layer):
+                    raise ValueError(
+                        "gold_annotation_ids should have the same length as the number of gold annotations."
+                    )
+            else:
+                current_gold_annotation_ids = None
+
             serialized_gold_annotations, new_gold_ann2id = serialize_annotations(
                 annotations=layer,
                 indices=indices,
                 # gold annotations can only reference other gold annotations
                 annotation2id=gold_annotation2id,
                 label_prefix=gold_label_prefix,
+                annotation_ids=current_gold_annotation_ids,
             )
             serialized_annotations.extend(serialized_gold_annotations)
             gold_annotation2id.update(new_gold_ann2id)
         if what in ["prediction", "both"]:
+            if prediction_annotation_ids is not None:
+                if len(prediction_annotation_ids) <= idx:
+                    raise ValueError(
+                        "prediction_annotation_ids should have the same length as the number of layers."
+                    )
+                current_prediction_annotation_ids = prediction_annotation_ids[idx]
+                if current_prediction_annotation_ids is not None and len(
+                    current_prediction_annotation_ids
+                ) != len(layer.predictions):
+                    raise ValueError(
+                        "prediction_annotation_ids should have the same length as the number of prediction annotations."
+                    )
+            else:
+                current_prediction_annotation_ids = None
             serialized_predicted_annotations, new_pred_ann2id = serialize_annotations(
                 annotations=layer.predictions,
                 indices=indices,
@@ -188,6 +234,7 @@ def serialize_annotation_layers(
                 # Note that predictions take precedence over gold annotations.
                 annotation2id={**gold_annotation2id, **prediction_annotation2id},
                 label_prefix=prediction_label_prefix,
+                annotation_ids=current_prediction_annotation_ids,
             )
             prediction_annotation2id.update(new_pred_ann2id)
             serialized_annotations.extend(serialized_predicted_annotations)
@@ -200,10 +247,6 @@ class BratSerializer(DocumentSerializer):
     specify the annotation layers to serialize. For now, it supports layers containing LabeledSpan,
     LabeledMultiSpan, and BinaryRelation annotations.
 
-    If a gold_label_prefix is provided, the gold annotations are serialized with the given prefix.
-    Otherwise, only the predicted annotations are serialized. A document_processor can be provided
-    to process documents before serialization.
-
     Attributes:
         layers: A mapping from annotation layer names that should be serialized to what should be
             serialized, i.e. "gold", "prediction", or "both".
@@ -212,21 +255,20 @@ class BratSerializer(DocumentSerializer):
             with the given string. Otherwise, only predicted annotations are serialized.
         prediction_label_prefix: If provided, labels of predicted annotations are prefixed with the
             given string.
-        default_kwargs: Additional keyword arguments to be used as defaults during serialization.
+        metadata_gold_id_keys: A dictionary mapping layer names to metadata keys that contain the
+            gold annotation IDs.
+        metadata_prediction_id_keys: A dictionary mapping layer names to metadata keys that contain
+            the prediction annotation IDs.
     """
 
     def __init__(
         self,
         layers: Dict[str, str],
         document_processor=None,
-        prediction_label_prefix=None,
-        gold_label_prefix=None,
         **kwargs,
     ):
         self.document_processor = document_processor
         self.layers = layers
-        self.prediction_label_prefix = prediction_label_prefix
-        self.gold_label_prefix = gold_label_prefix
         self.default_kwargs = kwargs
 
     def __call__(self, documents: Sequence[Document], **kwargs) -> Dict[str, str]:
@@ -235,8 +277,6 @@ class BratSerializer(DocumentSerializer):
         return self.write_with_defaults(
             documents=documents,
             layers=self.layers,
-            prediction_label_prefix=self.prediction_label_prefix,
-            gold_label_prefix=self.gold_label_prefix,
             **kwargs,
         )
 
@@ -254,6 +294,8 @@ class BratSerializer(DocumentSerializer):
         split: Optional[str] = None,
         gold_label_prefix: Optional[str] = None,
         prediction_label_prefix: Optional[str] = None,
+        metadata_gold_id_keys: Optional[Dict[str, str]] = None,
+        metadata_prediction_id_keys: Optional[Dict[str, str]] = None,
     ) -> Dict[str, str]:
 
         realpath = os.path.realpath(path)
@@ -280,10 +322,32 @@ class BratSerializer(DocumentSerializer):
             file_name = f"{doc_id}.ann"
             metadata_text[f"{file_name}"] = doc.text
             ann_path = os.path.join(realpath, file_name)
+            layer_names = list(layers)
+            if metadata_gold_id_keys is not None:
+                gold_annotation_ids = [
+                    doc.metadata[metadata_gold_id_keys[layer_name]]
+                    if layer_name in metadata_gold_id_keys
+                    else None
+                    for layer_name in layer_names
+                ]
+            else:
+                gold_annotation_ids = None
+
+            if metadata_prediction_id_keys is not None:
+                prediction_annotation_ids = [
+                    doc.metadata[metadata_prediction_id_keys[layer_name]]
+                    if layer_name in metadata_prediction_id_keys
+                    else None
+                    for layer_name in layer_names
+                ]
+            else:
+                prediction_annotation_ids = None
             serialized_annotations = serialize_annotation_layers(
-                layers=[(doc[layer_name], what) for layer_name, what in layers.items()],
+                layers=[(doc[layer_name], layers[layer_name]) for layer_name in layer_names],
                 gold_label_prefix=gold_label_prefix,
                 prediction_label_prefix=prediction_label_prefix,
+                gold_annotation_ids=gold_annotation_ids,
+                prediction_annotation_ids=prediction_annotation_ids,
             )
             with open(ann_path, "w+") as f:
                 f.writelines(serialized_annotations)


### PR DESCRIPTION
This PR adds the parameters `metadata_gold_id_keys` and `metadata_prediction_id_keys` to the `BratSerializer`:
- `metadata_gold_id_keys`: A dictionary mapping layer names to metadata keys that contain the gold annotation IDs.
- `metadata_prediction_id_keys`: A dictionary mapping layer names to metadata keys that contain the prediction annotation IDs.

Usage example:
```bash
+metadata_gold_id_keys.labeled_spans=entity_ids 
```
This will use the entries in `entity_ids` from the document metadata as IDs for when serializing the gold annotations from the `labeled_spans` layer.