### PR TITLE
fixes #175 default tags setting 

### DIFF
--- a/configs/extras/default.yaml
+++ b/configs/extras/default.yaml
@@ -2,7 +2,7 @@
 ignore_warnings: False
 
 # ask user for tags if none are provided in the config
-enforce_tags: True
+enforce_tags: False
 
 # pretty print config tree at the start of the run using Rich library
 print_config: True


### PR DESCRIPTION
As described in the issue #175, the default tags settings in the config file `extras/default.yaml` expect tags to be set. If no tags are set, the user is expected to enter appropriate tags. However, this lead to confusion as the process stops and awaits the user input.
</b>
For this reason, the `enforce_tags` variable is set to `False` instead of `True` in the config file. 
