### PR TITLE
Improve `SaveJobReturnValueCallback`

### DIFF
--- a/configs/hydra/default.yaml
+++ b/configs/hydra/default.yaml
@@ -11,6 +11,7 @@ defaults:
 callbacks:
   save_job_return:
     _target_: src.hydra_callbacks.SaveJobReturnValueCallback
+    integrate_multirun_result: true
     filenames:
       - job_return_value.json
       - job_return_value.md

--- a/configs/hydra/default.yaml
+++ b/configs/hydra/default.yaml
@@ -15,6 +15,7 @@ callbacks:
     filenames:
       - job_return_value.json
       - job_return_value.md
+    multirun_aggregator_blacklist: ["min", "25%", "50%", "75%", "max"]
 
 # output directory, generated dynamically on each run
 run:


### PR DESCRIPTION
This PR combines the changes of three PRs in a downstream project.

1. add parameter `multirun_aggregator_blacklist` to `SaveJobReturnValueCallback` 
...and also set `multirun_aggregator_blacklist: ["min", "25%", "50%", "75%", "max"]` as default value in the config. From the docstring:
```
multirun_aggregator_blacklist: List[str] (default: None)
        A list of keys to exclude from the aggregation (of multirun results), such as "count" or "25%". If None,
        all keys are included. See pd.DataFrame.describe() for possible aggregation keys.
        For numeric values, it is recommended to use ["min", "25%", "50%", "75%", "max"]
        which will result in keeping only the count, mean and std values.
```
2. fix multirun result as markdown for `integrate_multirun_result=False`
3. set `integrate_multirun_result` per default to true

## TL;DR:
- add parameter `multirun_aggregator_blacklist` to `SaveJobReturnValueCallback` 
- fix multirun result as markdown for `integrate_multirun_result=False`
- set `integrate_multirun_result` to true per default 
- set `multirun_aggregator_blacklist` to `["min", "25%", "50%", "75%", "max"]` per default

