### PR TITLE
remove dublicated slash in default paths 

### DIFF
--- a/configs/paths/default.yaml
+++ b/configs/paths/default.yaml
@@ -4,10 +4,10 @@
 root_dir: ${oc.env:PROJECT_ROOT}
 
 # path to data directory
-data_dir: ${paths.root_dir}/data/
+data_dir: ${paths.root_dir}/data
 
 # path to logging directory
-log_dir: ${paths.root_dir}/logs/
+log_dir: ${paths.root_dir}/logs
 
 # path to output directory, created dynamically by hydra
 # path generation pattern is specified in `configs/hydra/default.yaml`


### PR DESCRIPTION
remove trailing slash in default `data_dir` and `log_dir`