### PR TITLE
add `combine_job_returns.py`

### DIFF
--- a/src/analysis/combine_job_returns.py
+++ b/src/analysis/combine_job_returns.py
@@ -1,0 +1,260 @@
+import pyrootutils
+
+root = pyrootutils.setup_root(
+    search_from=__file__,
+    indicator=[".project-root"],
+    pythonpath=True,
+    dotenv=False,
+)
+import argparse
+import logging
+import os
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from pandas import MultiIndex
+
+from src.analysis.common import read_nested_jsons
+
+logger = logging.getLogger(__name__)
+
+
+def separate_path_and_id(
+    path_and_maybe_id: str, separator: str = ":"
+) -> Tuple[Optional[str], str]:
+    parts = path_and_maybe_id.split(separator, 1)
+    if len(parts) == 1:
+        return None, parts[0]
+    return parts[0], parts[1]
+
+
+def get_file_paths(paths_file: str, file_name: str, use_aggregated: bool) -> Dict[str, str]:
+    with open(paths_file, "r") as f:
+        paths_maybe_with_ids = f.readlines()
+    ids, paths = zip(*[separate_path_and_id(path.strip()) for path in paths_maybe_with_ids])
+
+    if use_aggregated:
+        file_base_name, ext = os.path.splitext(file_name)
+        file_name = f"{file_base_name}.aggregated{ext}"
+    file_paths = [os.path.join(path, file_name) for path in paths]
+    return {
+        id if id is not None else f"idx={idx}": path
+        for idx, (id, path) in enumerate(zip(ids, file_paths))
+    }
+
+
+def get_job_id_col(index: pd.MultiIndex) -> Optional[Tuple]:
+    for idx in index:
+        if "job_id" in idx:
+            return idx
+    return None
+
+
+def remove_part_from_multi_index(index: pd.MultiIndex, part: str) -> pd.MultiIndex:
+    new_index = []
+    for idx in index:
+        new_idx = tuple([i for i in idx if i != part])
+        new_index.append(new_idx)
+    return MultiIndex.from_tuples(new_index)
+
+
+def main(
+    paths_file: str,
+    file_name: str,
+    use_aggregated: bool,
+    columns: Optional[List[str]],
+    round_precision: Optional[int],
+    format: str,
+    transpose: bool = False,
+    unpack_multirun_results: bool = False,
+    unpack_multirun_results_with_job_id: bool = False,
+    in_percent: bool = False,
+    reset_index: bool = False,
+):
+    file_paths = get_file_paths(
+        paths_file=paths_file, file_name=file_name, use_aggregated=use_aggregated
+    )
+    data = read_nested_jsons(json_paths=file_paths)
+
+    job_id_col = get_job_id_col(data.columns)
+
+    if columns is not None:
+        columns_multi_index = [
+            tuple([part or np.nan for part in col.split("/")]) for col in columns
+        ]
+        if unpack_multirun_results_with_job_id:
+            if job_id_col is None:
+                raise ValueError("Job ID column not found in the data.")
+            if job_id_col not in columns_multi_index:
+                columns_multi_index.append(job_id_col)
+        try:
+            available_cols = data.columns.tolist()
+            for col in columns_multi_index:
+                if col not in available_cols:
+                    raise KeyError(f"Column {col} not found in the data.")
+            data_series = [data[col] for col in columns_multi_index]
+        except KeyError as e:
+            print(
+                f"Columns {columns_multi_index} not found in the data. Available columns are {list(data.columns)}."
+            )
+            raise e
+        data = pd.concat(data_series, axis=1)
+
+    # drop rows that are all NaN
+    data = data.dropna(how="all")
+
+    # if more than one data point, drop the index levels that are everywhere the same
+    if len(data) > 1:
+        unique_levels = [
+            idx
+            for idx, level in enumerate(data.index.levels)
+            if len(data.index.get_level_values(idx).unique()) == 1
+        ]
+        for level in sorted(unique_levels, reverse=True):
+            data.index = data.index.droplevel(level)
+
+    # if more than one column, drop the columns that are everywhere the same
+    if len(data.columns) > 1:
+        unique_column_levels = [
+            idx
+            for idx, level in enumerate(data.columns.levels)
+            if len(data.columns.get_level_values(idx).unique()) == 1
+        ]
+        for level in sorted(unique_column_levels, reverse=True):
+            data.columns = data.columns.droplevel(level)
+
+    if unpack_multirun_results or unpack_multirun_results_with_job_id:
+        index_names = list(data.index.names)
+        data_series_lists = data.copy()
+        job_ids = None
+        if job_id_col in data_series_lists.columns:
+            job_ids_series = data_series_lists.pop(job_id_col)
+            job_ids_frame = pd.DataFrame(pd.DataFrame.from_records(job_ids_series.values))
+            job_ids_frame.index = job_ids_series.index
+            # check that all rows are identical
+            if job_ids_frame.nunique().max():
+                job_ids = job_ids_frame.iloc[0]
+            else:
+                logger.warning(
+                    "Job IDs are not identical across all rows. Cannot unpack "
+                    "multirun results with job ids as columns."
+                )
+
+        while not isinstance(data_series_lists, pd.Series):
+            data_series_lists = data_series_lists.stack(future_stack=True)
+        data_series_lists = data_series_lists.dropna()
+        data = pd.DataFrame.from_records(data_series_lists.values, index=data_series_lists.index)
+        if job_ids is not None:
+            data.columns = job_ids
+        num_col_levels = data.index.nlevels - len(index_names)
+        for _ in range(num_col_levels):
+            data = data.unstack()
+        data.columns = data.columns.swaplevel(0, -1)
+        data = data.dropna(how="all", axis="columns")
+
+    # needs to happen before rounding, otherwise the rounding will be off
+    if in_percent:
+        data = data * 100
+
+    if round_precision is not None:
+        data = data.round(round_precision)
+
+    # needs to happen before transposing
+    if format == "markdown_mean_and_std":
+        if data.columns.nlevels == 1:
+            data.columns = pd.MultiIndex.from_tuples([(col,) for col in data.columns.tolist()])
+
+        # get mean columns
+        mean_col_names = [col for col in data.columns if "mean" in col]
+        mean_columns = data[mean_col_names].copy()
+        # remove all "mean" from col names
+        mean_columns.columns = remove_part_from_multi_index(mean_columns.columns, "mean")
+        # get std columns
+        std_col_names = [col for col in data.columns if "std" in col]
+        std_columns = data[std_col_names].copy()
+        # remove all "std" from col names
+        std_columns.columns = remove_part_from_multi_index(std_columns.columns, "std")
+        # sanity check
+        if not mean_columns.columns.equals(std_columns.columns):
+            raise ValueError("Mean and std columns do not match.")
+        mean_and_std = mean_columns.astype(str) + " ± " + std_columns.astype(str)
+        mean_and_std.columns = [
+            ("mean ± std",) + (tuple(col) if col != ((),) else ()) for col in mean_columns.columns
+        ]
+        # remove mean and std columns from data
+        # we can not use drop because the columns is a multiindex that may contain NaNs
+        other_cols = [
+            col for col in data.columns if col not in set(mean_col_names + std_col_names)
+        ]
+        data = data[other_cols]
+        # add mean and std columns to data
+        data = pd.concat([data, mean_and_std], axis=1)
+        if data.columns.nlevels == 1:
+            data.columns = data.columns.to_flat_index()
+            data.columns = [
+                "/".join(col) if isinstance(col, tuple) else col for col in data.columns
+            ]
+
+    if transpose:
+        data = data.T
+
+    if reset_index:
+        data = data.reset_index()
+
+    if format in ["markdown", "markdown_mean_and_std"]:
+        print(data.to_markdown(index=not reset_index))
+    elif format == "json":
+        print(data.to_json())
+    else:
+        raise ValueError(f"Invalid format: {format}. Use 'markdown' or 'json'.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Combine job returns and show as Markdown table")
+    parser.add_argument(
+        "--paths-file", type=str, help="Path to the file containing the paths to the job returns"
+    )
+    parser.add_argument(
+        "--use-aggregated", action="store_true", help="Whether to use the aggregated job returns"
+    )
+    parser.add_argument(
+        "--file-name",
+        type=str,
+        default="job_return_value.json",
+        help="Name of the file to write the aggregated job returns to",
+    )
+    parser.add_argument(
+        "--columns", type=str, nargs="+", help="Columns to select from the combined job returns"
+    )
+    parser.add_argument(
+        "--unpack-multirun-results", action="store_true", help="Unpack multirun results"
+    )
+    parser.add_argument(
+        "--unpack-multirun-results-with-job-id",
+        action="store_true",
+        help="Unpack multirun results with job ID",
+    )
+    parser.add_argument("--transpose", action="store_true", help="Transpose the table")
+    parser.add_argument(
+        "--round-precision",
+        type=int,
+        help="Round the values in the combined job returns to the specified precision",
+    )
+    parser.add_argument(
+        "--in-percent", action="store_true", help="Show the values in percent (multiply by 100)"
+    )
+    parser.add_argument(
+        "--reset-index", action="store_true", help="Reset the index of the combined job returns"
+    )
+    parser.add_argument(
+        "--format",
+        type=str,
+        default="markdown",
+        choices=["markdown", "markdown_mean_and_std", "json"],
+        help="Format to output the combined job returns",
+    )
+
+    args = parser.parse_args()
+    kwargs = vars(args)
+    main(**kwargs)

--- a/src/analysis/combine_job_returns.py
+++ b/src/analysis/combine_job_returns.py
@@ -211,7 +211,9 @@ def main(
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Combine job returns and show as Markdown table")
+    parser = argparse.ArgumentParser(
+        description="Combine job returns and show as Markdown table or Json"
+    )
     parser.add_argument(
         "--paths-file", type=str, help="Path to the file containing the paths to the job returns"
     )

--- a/src/analysis/common.py
+++ b/src/analysis/common.py
@@ -1,0 +1,47 @@
+import json
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+
+def parse_identifier(
+    identifier_str, defaults: Dict[str, str], parts_sep: str = ",", key_val_sep: str = "="
+) -> Dict[str, str]:
+    parts = [
+        part.split(key_val_sep)
+        for part in identifier_str.strip().split(parts_sep)
+        if key_val_sep in part
+    ]
+    parts_dict = dict(parts)
+    return {**defaults, **parts_dict}
+
+
+def read_nested_json(path: str) -> pd.DataFrame:
+    # Read the nested JSON data into a pandas DataFrame
+    with open(path, "r") as f:
+        data = json.load(f)
+    result = pd.json_normalize(data, sep="/")
+    result.index.name = "entry"
+    return result
+
+
+def read_nested_jsons(
+    json_paths: Dict[str, str],
+    default_key_values: Optional[Dict[str, str]] = None,
+    column_level_names: Optional[List[str]] = None,
+) -> pd.DataFrame:
+    identifier_strings = json_paths.keys()
+    dfs = [read_nested_json(json_paths[identifier_str]) for identifier_str in identifier_strings]
+    new_index_levels = pd.MultiIndex.from_frame(
+        pd.DataFrame(
+            [
+                parse_identifier(identifier_str, default_key_values or {})
+                for identifier_str in identifier_strings
+            ]
+        )
+    )
+    dfs_concat = pd.concat(dfs, keys=list(new_index_levels), names=new_index_levels.names, axis=0)
+    dfs_concat.columns = pd.MultiIndex.from_tuples(
+        [col.split("/") for col in dfs_concat.columns], names=column_level_names
+    )
+    return dfs_concat


### PR DESCRIPTION
from the help (`python src/analysis/combine_job_returns.py -h`):
```
usage: combine_job_returns.py [-h] [--paths-file PATHS_FILE] [--use-aggregated] [--file-name FILE_NAME] [--columns COLUMNS [COLUMNS ...]] [--unpack-multirun-results]
                              [--unpack-multirun-results-with-job-id] [--transpose] [--round-precision ROUND_PRECISION] [--in-percent] [--reset-index]
                              [--format {markdown,markdown_mean_and_std,json}]

Combine job returns and show as Markdown table or Json

optional arguments:
  -h, --help            show this help message and exit
  --paths-file PATHS_FILE
                        Path to the file containing the paths to the job returns
  --use-aggregated      Whether to use the aggregated job returns
  --file-name FILE_NAME
                        Name of the file to write the aggregated job returns to
  --columns COLUMNS [COLUMNS ...]
                        Columns to select from the combined job returns
  --unpack-multirun-results
                        Unpack multirun results
  --unpack-multirun-results-with-job-id
                        Unpack multirun results with job ID
  --transpose           Transpose the table
  --round-precision ROUND_PRECISION
                        Round the values in the combined job returns to the specified precision
  --in-percent          Show the values in percent (multiply by 100)
  --reset-index         Reset the index of the combined job returns
  --format {markdown,markdown_mean_and_std,json}
                        Format to output the combined job returns
```

This requires the output from commands (probably evaluations, i.e.,  calling `src/evaluate_documents.py`) called with:
```
+hydra.callbacks.save_job_return.multirun_paths_file=PATHS_FILE \
+hydra.callbacks.save_job_return.multirun_path_id="KEY_1=VALUE_1,KEY_2=VALUE_2,KEY_N=VALUE_N" \
``` 
where `PATHS_FILE` should be used as `--paths-file` when calling `src/analysis/combine_job_returns.py`. `KEY_1`, `KEY_2` will be the index levels and `VALUE_1`, etc, the respective index values in the result table. Don't forget the quotation marks, they are required to not confuse Hydra! 

It will produce sth like:

| task   | relaxed_span   | criterion   | mean ± std   |
|:-------|:---------------|:------------|:-------------|
| adur   | false          | component   | 70.7 ± 0.35  |
| adur   | false          | span        | 83.67 ± 0.21 |
| adur   | true           | component   | 77.27 ± 0.55 |
| adur   | true           | span        | 92.17 ± 0.32 |
| are    | false          | rel&comp    | 18.04 ± 1.04 |
| are    | false          | relation    | 24.43 ± 1.14 |
| are    | false          | link        | 24.97 ± 1.12 |
| are    | true           | rel&comp    | 19.8 ± 1.06  |
| are    | true           | relation    | 27.06 ± 1.08 |
| are    | true           | link        | 27.8 ± 1.0   |

This result was created with the following parameters:
```
python src/analysis/combine_job_returns.py \
--paths-file PATHS_FILE/CREATED/FROM/MULTIPLE/F1METRIC/CALLS \
--use-aggregated \
--columns test/MICRO/f1/mean test/MICRO/f1/std \
--round-precision 2 \
--in-percent \
--reset-index \
--format markdown_mean_and_std
```

and values for `+hydra.callbacks.save_job_return.multirun_path_id` (the quotation marks are important!):
 - `"task=adur,relaxed_span=true,criterion=component"`
 - `"task=adur,relaxed_span=true,criterion=span"`
 - etc.

Requires: https://github.com/ArneBinder/pytorch-ie-hydra-template-1/pull/187 (for parameters `multirun_paths_file` and `multirun_path_id`)


I use this directly in my evaluation result analysis scripts. 

<details><summary>click here to see an actual example script</summary>


Each METRIC COMMAND will become a row in the result table!

```bash
#!/bin/sh

# This is a bash script that runs multiple evaluations on the model predictions.
# It communicates via a file with the Python script that actually performs the evaluation.
# First, it is checked if the file `HYDRA_MULTIRUN_PATHS_FILE` is there. If not,
# the script runs the evaluation commands. Internally, each call will append an output
# path to the `HYDRA_MULTIRUN_PATHS_FILE` file. Finally, the eval results are combined and
# shown on the command line.
#
# The script expects one or multiple *comma separated* paths as first argument. All remaining
# arguments will be passed to the combine script, i.e., src/analysis/combine_job_returns.py,
# see there for further information and optional arguments (e.g. to select only relevant columns).

BASE_FILE_NAME="evaluate_cdcp"
HYDRA_MULTIRUN_PATHS_DIR="hydra_multirun_paths"

# use the first argument as the data directory
DATA_DIR=$1
# shift the arguments to pass the rest to the combine_job_returns.py script
shift 1

# create the directory if it does not exist
mkdir -p "$HYDRA_MULTIRUN_PATHS_DIR"

DATA_DIR_HASH=$(echo "$DATA_DIR" | sha256sum | cut -c1-8)
HYDRA_MULTIRUN_PATHS_FILE="$HYDRA_MULTIRUN_PATHS_DIR/$BASE_FILE_NAME.$DATA_DIR_HASH.txt"

echo "Using paths file: $HYDRA_MULTIRUN_PATHS_FILE"

# Check if the file is there and only run the evaluation commands if it is not
if [ -f "$HYDRA_MULTIRUN_PATHS_FILE" ]; then
    # for now, we will throw an error if the file already exists
    echo "WARNING: The paths file already exists. Just the combination of results is performed."
else
  # Run the hydra commands
  echo "Running hydra commands..."

  # METRIC COMMAND 1: ADUs: default
  python src/evaluate_documents.py \
  "+dataset.data_dir=$DATA_DIR" \
  metric.layer=labeled_spans \
  +metric.labels=INFERRED \
  "+hydra.callbacks.save_job_return.multirun_paths_file=$HYDRA_MULTIRUN_PATHS_FILE" \
  '+hydra.callbacks.save_job_return.multirun_path_id="task=adur,relaxed_span=false,criterion=component"' \
  --multirun

  # METRIC COMMAND 2: ADUs: blanked
  python src/evaluate_documents.py \
  dataset=from_serialized_documents_with_preprocessing \
  +dataset.input.data_dir="$DATA_DIR" \
  dataset.relabel_annotations._enabled_=true \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.fact=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.policy=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.reference=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.testimony=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.value=adu \
  metric.layer=labeled_spans \
  +metric.labels=INFERRED \
  "+hydra.callbacks.save_job_return.multirun_paths_file=$HYDRA_MULTIRUN_PATHS_FILE" \
  '+hydra.callbacks.save_job_return.multirun_path_id="task=adur,relaxed_span=false,criterion=span"' \
  --multirun

  # METRIC COMMAND 3: ADUs: default relaxed
  python src/evaluate_documents.py \
  dataset=from_serialized_documents_with_preprocessing \
  +dataset.input.data_dir="$DATA_DIR" \
  dataset.align_predicted_spans._enabled_=true \
  metric.layer=labeled_spans \
  +metric.labels=INFERRED \
  "+hydra.callbacks.save_job_return.multirun_paths_file=$HYDRA_MULTIRUN_PATHS_FILE" \
  '+hydra.callbacks.save_job_return.multirun_path_id="task=adur,relaxed_span=true,criterion=component"' \
  --multirun

  # METRIC COMMAND 4: ADUs: blanked relaxed
  python src/evaluate_documents.py \
  dataset=from_serialized_documents_with_preprocessing \
  +dataset.input.data_dir="$DATA_DIR" \
  dataset.align_predicted_spans._enabled_=true \
  dataset.relabel_annotations._enabled_=true \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.fact=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.policy=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.reference=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.testimony=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.value=adu \
  metric.layer=labeled_spans \
  +metric.labels=INFERRED \
  "+hydra.callbacks.save_job_return.multirun_paths_file=$HYDRA_MULTIRUN_PATHS_FILE" \
  '+hydra.callbacks.save_job_return.multirun_path_id="task=adur,relaxed_span=true,criterion=span"' \
  --multirun

  # METRIC COMMAND 5: relations: default
  python src/evaluate_documents.py \
  +dataset.data_dir="$DATA_DIR" \
  metric.layer=binary_relations \
  +metric.labels=INFERRED \
  "+hydra.callbacks.save_job_return.multirun_paths_file=$HYDRA_MULTIRUN_PATHS_FILE" \
  '+hydra.callbacks.save_job_return.multirun_path_id="task=are,relaxed_span=false,criterion=rel&comp"' \
  --multirun

  # METRIC COMMAND 6: relations: blanked adus
  python src/evaluate_documents.py \
  dataset=from_serialized_documents_with_preprocessing \
  +dataset.input.data_dir="$DATA_DIR" \
  dataset.relabel_annotations._enabled_=true \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.fact=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.policy=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.reference=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.testimony=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.value=adu \
  metric.layer=binary_relations \
  +metric.labels=INFERRED \
  "+hydra.callbacks.save_job_return.multirun_paths_file=$HYDRA_MULTIRUN_PATHS_FILE" \
  '+hydra.callbacks.save_job_return.multirun_path_id="task=are,relaxed_span=false,criterion=relation"' \
  --multirun

  # METRIC COMMAND 7: relations: blanked adus and relations
  python src/evaluate_documents.py \
  dataset=from_serialized_documents_with_preprocessing \
  +dataset.input.data_dir="$DATA_DIR" \
  dataset.relabel_annotations._enabled_=true \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.fact=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.policy=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.reference=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.testimony=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.value=adu \
  +dataset.relabel_annotations.function.label_mapping.binary_relations.evidence=relation \
  +dataset.relabel_annotations.function.label_mapping.binary_relations.reason=relation \
  metric.layer=binary_relations \
  +metric.labels=INFERRED \
  "+hydra.callbacks.save_job_return.multirun_paths_file=$HYDRA_MULTIRUN_PATHS_FILE" \
  '+hydra.callbacks.save_job_return.multirun_path_id="task=are,relaxed_span=false,criterion=link"' \
  --multirun

    # METRIC COMMAND 8: relations: default relaxed
  python src/evaluate_documents.py \
  dataset=from_serialized_documents_with_preprocessing \
  +dataset.input.data_dir="$DATA_DIR" \
  dataset.align_predicted_spans._enabled_=true \
  metric.layer=binary_relations \
  +metric.labels=INFERRED \
  "+hydra.callbacks.save_job_return.multirun_paths_file=$HYDRA_MULTIRUN_PATHS_FILE" \
  '+hydra.callbacks.save_job_return.multirun_path_id="task=are,relaxed_span=true,criterion=rel&comp"' \
  --multirun

  # METRIC COMMAND 9: relations: blanked adus relaxed
  python src/evaluate_documents.py \
  dataset=from_serialized_documents_with_preprocessing \
  +dataset.input.data_dir="$DATA_DIR" \
  dataset.align_predicted_spans._enabled_=true \
  dataset.relabel_annotations._enabled_=true \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.fact=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.policy=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.reference=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.testimony=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.value=adu \
  metric.layer=binary_relations \
  +metric.labels=INFERRED \
  "+hydra.callbacks.save_job_return.multirun_paths_file=$HYDRA_MULTIRUN_PATHS_FILE" \
  '+hydra.callbacks.save_job_return.multirun_path_id="task=are,relaxed_span=true,criterion=relation"' \
  --multirun

  # METRIC COMMAND 10: relations: blanked adus and relations relaxed
  python src/evaluate_documents.py \
  dataset=from_serialized_documents_with_preprocessing \
  +dataset.input.data_dir="$DATA_DIR" \
  dataset.align_predicted_spans._enabled_=true \
  dataset.relabel_annotations._enabled_=true \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.fact=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.policy=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.reference=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.testimony=adu \
  +dataset.relabel_annotations.function.label_mapping.labeled_spans.value=adu \
  +dataset.relabel_annotations.function.label_mapping.binary_relations.evidence=relation \
  +dataset.relabel_annotations.function.label_mapping.binary_relations.reason=relation \
  metric.layer=binary_relations \
  +metric.labels=INFERRED \
  "+hydra.callbacks.save_job_return.multirun_paths_file=$HYDRA_MULTIRUN_PATHS_FILE" \
  '+hydra.callbacks.save_job_return.multirun_path_id="task=are,relaxed_span=true,criterion=link"' \
  --multirun

fi

# combine results: pass the rest of the arguments to the script
python src/analysis/combine_job_returns.py --paths-file "$HYDRA_MULTIRUN_PATHS_FILE" "$@"
```

</details>