### PR TITLE
`DocumentSerializer` implementations require `split` parameter

### DIFF
--- a/configs/serializer/brat.yaml
+++ b/configs/serializer/brat.yaml
@@ -1,6 +1,5 @@
 _target_: src.serializer.BratSerializer
 path: ${paths.prediction_save_dir}
-split: ${dataset_split}
 
 # this needs to be a mapping from annotation layer names
 # to what to serialize, i.e. "gold", "prediction", or "both".

--- a/configs/serializer/json.yaml
+++ b/configs/serializer/json.yaml
@@ -1,3 +1,2 @@
 _target_: src.serializer.JsonSerializer
 path: ${paths.prediction_save_dir}
-split: ${dataset_split}

--- a/src/predict.py
+++ b/src/predict.py
@@ -98,7 +98,9 @@ def predict(cfg: DictConfig) -> Tuple[dict, dict]:
     serializer: Optional[DocumentSerializer] = None
     if cfg.get("serializer") and cfg.serializer.get("_target_"):
         log.info(f"Instantiating serializer <{cfg.serializer._target_}>")
-        serializer = hydra.utils.instantiate(cfg.serializer, _convert_="partial")
+        serializer = hydra.utils.instantiate(
+            cfg.serializer, split=cfg.dataset_split, _convert_="partial"
+        )
 
     # select the dataset split for prediction
     dataset_predict = dataset[cfg.dataset_split]

--- a/src/serializer/interface.py
+++ b/src/serializer/interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Iterable
+from typing import Any, Iterable, Optional
 
 from pytorch_ie.core import Document
 
@@ -10,6 +10,9 @@ class DocumentSerializer(ABC):
     The serializer should not return the serialized documents, but write them to disk and instead
     return some metadata such as the path to the serialized documents.
     """
+
+    @abstractmethod
+    def __init__(self, split: Optional[str] = None, **kwargs) -> None: ...
 
     @abstractmethod
     def __call__(self, documents: Iterable[Document], append: bool = False, **kwargs) -> Any: ...


### PR DESCRIPTION
this allows to pass the `split` during (hydra) instantiation of the serializer

context: #193