### PR TITLE
import `AutoPipeline` from `pytorch_ie` root instead of `pytorch_ie.auto`

### DIFF
--- a/configs/pipeline/_from_pretrained.yaml
+++ b/configs/pipeline/_from_pretrained.yaml
@@ -1,3 +1,3 @@
-_target_: pytorch_ie.auto.AutoPipeline.from_pretrained
+_target_: pytorch_ie.AutoPipeline.from_pretrained
 pretrained_model_name_or_path: ???
 show_progress_bar: true


### PR DESCRIPTION
`pytorch_ie.auto` will be removed soon from PyTorchIE (see follow-ups of https://github.com/ArneBinder/pytorch-ie/pull/456)