### PR TITLE
harden serializer usage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # --------- pytorch-ie --------- #
 pytorch-ie>=0.31.8,<0.32.0
-pie-datasets>=0.10.8,<0.11.0
+pie-datasets>=0.10.10,<0.11.0
 pie-modules>=0.12.1,<0.13.0
 
 # --------- hydra --------- #

--- a/src/serializer/json.py
+++ b/src/serializer/json.py
@@ -31,9 +31,7 @@ class JsonSerializer(DocumentSerializer):
                 documents = Dataset.from_documents(documents)
 
         dataset_dict = DatasetDict({split: documents})
-        # TODO: pass append to DatasetDict.to_json,
-        #  requires https://github.com/ArneBinder/pie-datasets/issues/158
-        dataset_dict.to_json(path=path)
+        dataset_dict.to_json(path=path, mode="a" if append else "w")
         return {"path": path, "split": split}
 
     @classmethod

--- a/src/utils/inference_utils.py
+++ b/src/utils/inference_utils.py
@@ -47,10 +47,10 @@ def predict_and_serialize(
     batch_iter: Union[Sequence[Iterable[Document]], Iterable[Sequence[Document]]]
     if document_batch_size is None:
         batch_iter = [dataset]
-        append = False
     else:
         batch_iter = document_batch_iter(dataset=dataset, batch_size=document_batch_size)
-        append = True
+
+    append = False
     for docs_batch in batch_iter:
         if pipeline is not None:
             t_start = timeit.default_timer()
@@ -68,6 +68,7 @@ def predict_and_serialize(
                     " during prediction. Only the last result is returned."
                 )
             result["serializer"] = serializer_result
+            append = True
 
     if prediction_time is not None:
         result["prediction_time"] = prediction_time


### PR DESCRIPTION
This also fixes `predict_and_serialize`: first serializer call with `append=False`, subsequent calls with `append=True`