### PR TITLE
set model to training mode before starting training

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -206,6 +206,10 @@ def train(cfg: DictConfig) -> Tuple[dict, dict]:
         log.warning("the taskmodule is not saved because no save_dir is specified")
 
     if cfg.get("train"):
+        # Set model in training mode (since pytorch-lightning 2.2.0 the model is not set
+        # to train mode automatically in trainer.fit). To just partly train the model
+        # (e.g. only some layers), override the train() method in your model.
+        model.train()
         log.info("Starting training!")
         trainer.fit(model=model, datamodule=datamodule, ckpt_path=cfg.get("ckpt_path"))
 


### PR DESCRIPTION
From `pytorch-lightning` 2.2 onwards, the models are not automatically set to train mode during training (see section "Improved Handling of Evaluation Mode" in the [release notes](https://github.com/Lightning-AI/pytorch-lightning/releases/tag/2.2.0)). this affects e.g. loaded Huggingface transformer models.

With this PR, we explicitly set the model into training mode via `model.train()` before the actual training starts.

To just partly train the model (e.g. only some layers), the user is advised to override the `train()` method in their model.