### PR TITLE
add SciArg experiments: `sciarg_adur` and `sciarg_are`

### DIFF
--- a/configs/dataset/sciarg_base.yaml
+++ b/configs/dataset/sciarg_base.yaml
@@ -1,0 +1,5 @@
+_target_: src.utils.execute_pipeline
+input:
+  _target_: pie_datasets.DatasetDict.load_dataset
+  path: pie/sciarg
+  revision: ad5888136b16308c168aa52f9b1193636ad84cec

--- a/configs/dataset/sciarg_prepared.yaml
+++ b/configs/dataset/sciarg_prepared.yaml
@@ -1,0 +1,14 @@
+# Simple preprocessing pipeline that loads conll2003 and allows to select a subset of documents. Uses all
+# documents per default.
+
+# Usage:
+# Just use dataset=conll2003_select_n and set any "stop" parameter,
+# e.g. dataset.select_n.stop=5 to take only 5 train documents. See _select_n.yaml for further options.
+
+defaults:
+  - sciarg_base
+  - _create_test_split_by_ids
+  - _create_validation_split
+
+create_test_split:
+  ids: ["A32", "A33", "A34", "A35", "A36", "A37", "A38", "A39", "A40"]

--- a/configs/experiment/sciarg_adur.yaml
+++ b/configs/experiment/sciarg_adur.yaml
@@ -1,0 +1,82 @@
+# @package _global_
+
+# This is a replication of the setup for ADU recognition from the paper (minor differences, see below):
+#   Arne Binder, Leonhard Hennig, and Bhuvanesh Verma. 2022. Full-Text Argumentation Mining on Scientific Publications.
+#   In Proceedings of the first Workshop on Information Extraction from Scientific Publications, pages 54–66, Online.
+#   Association for Computational Linguistics.
+
+# Differences to the paper:
+# - In the case that the input exceeds the maximum input length of the PLM, we do not concatenate the output
+#   of the PLM before feeding it to the LSTM. Instead, we process the parts separately until the end. This is
+#   a disadvantage when compared to the paper, but the current version of the PIE framework does not support
+#   this feature yet. In the future, we may use a window_overlap of e.g. 64 to compensate for this.
+# - The paper does not train the base model but this experiment does. However, with a lower learning rate (5e-5).
+# - The paper uses metric/token/macro/f1/val as monitor metric to decide which model should be saved in the end.
+#   This experiment uses metric/span/micro/f1/val.
+# - The paper uses 5 fold cross validation but this experiment uses a fixed validation set.
+
+# Furthermore, this uses hyperparameters that were found as
+# result from hyperparameter optimization with experiment=sciarg_adur and
+# hparams_search=adur_scientific_token_classification_with_crf @400000 total steps
+
+# to execute this experiment run:
+# python train.py experiment=sciarg_adur
+
+defaults:
+  - override /dataset: sciarg_prepared
+  - override /datamodule: default
+  - override /taskmodule: labeled_span_extraction_by_token_classification
+  - override /model: token_classification_with_seq2seq_encoder_and_crf
+  - override /callbacks: default
+  - override /logger: wandb
+  - override /trainer: default
+
+# name of the run determines folder name in logs
+name: "dataset-sciarg/task-adur"
+
+monitor_metric: "metric/span/micro/f1/val"
+
+tags: ["dataset=sciarg", "task=adur", "model=token_classification_with_crf"]
+
+seed: 12345
+
+transformer_model: allenai/scibert_scivocab_uncased
+
+taskmodule:
+  tokenizer_name_or_path: ${transformer_model}
+  tokenize_kwargs:
+    max_length: 512
+    stride: 64
+    return_overflowing_tokens: true
+  partition_annotation: labeled_partitions
+
+model:
+  model_name_or_path: ${transformer_model}
+  freeze_base_model: false
+  seq2seq_encoder:
+    type: sequential
+    drop0:
+      type: dropout
+      p: 0.5
+    lstm0:
+      type: lstm
+      num_layers: 2
+      bidirectional: true
+      hidden_size: 300
+      dropout: 0.4394
+  use_crf: true
+  learning_rate: 0.00003
+  task_learning_rate: 0.00003
+
+datamodule:
+  batch_size: 8
+
+trainer:
+  gradient_clip_val: 7.0
+  gradient_clip_algorithm: norm
+  min_epochs: 20
+  max_epochs: 200
+
+callbacks:
+  early_stopping:
+    patience: 50

--- a/configs/experiment/sciarg_are.yaml
+++ b/configs/experiment/sciarg_are.yaml
@@ -1,0 +1,75 @@
+# @package _global_
+
+# this is for Argumentative Relation Extraction (ARE) on scientific datasets
+# parameters from the command here: https://github.com/ArneBinder/pie-document-level/issues/355#issuecomment-2606980385
+# $HOME/projects/pegasus-bridle/wrapper.sh python src/train.py \
+#experiment=sciarg_relations \
+#dataset=sciarg_prepared_with_fixed_validation_and_more_train \
+#transformer_model=allenai/scibert_scivocab_uncased \
+#model.warmup_proportion=0.1 \
+#taskmodule.collect_statistics=true \
+#trainer.min_epochs=75 \
+#trainer.max_epochs=75 \
+#monitor_metric=metric/micro/f1_without_tn/val \
+#datamodule.batch_size=128 \
+#datamodule.num_workers=12 \
+#trainer=gpu \
+#test=true \
+#name=dataset-sciarg/task-relations/v0.4 \
+#seed=1,12,123 \
+#--multirun
+
+# result from hyperparameter optimization with experiment=sciarg_are and
+# hparams_search=are_scientific_argument_marked_text_classification @1000000 total steps
+
+# to execute this experiment run:
+# python train.py experiment=sciarg_are
+
+defaults:
+  - override /dataset: sciarg_prepared
+  - override /datamodule: default
+  - override /taskmodule: re_text_classification_with_indices
+  - override /model: sequence_classification_with_pooler
+  - override /callbacks: default
+  - override /logger: wandb
+  - override /trainer: default
+
+# name of the run determines folder name in logs
+name: "dataset-sciarg/task-are"
+
+monitor_metric: "metric/micro/f1_without_tn/val"
+monitor_mode: "max"
+
+tags:
+  ["dataset=sciarg", "task=are", "model=argument_marked_text_classification"]
+
+seed: 12345
+
+transformer_model: "allenai/scibert_scivocab_uncased"
+
+taskmodule:
+  tokenizer_name_or_path: ${transformer_model}
+  max_window: 512
+  add_reversed_relations: true
+  add_candidate_relations: true
+  max_argument_distance: 20
+  collect_statistics: true
+  partition_annotation: labeled_partitions
+  symmetric_relations:
+    - semantically_same
+    - parts_of_same
+    - contradicts
+
+model:
+  model_name_or_path: ${transformer_model}
+  learning_rate: 1e-4
+  task_learning_rate: 3e-4
+  warmup_proportion: 0.1
+
+datamodule:
+  batch_size: 8
+
+trainer:
+  min_epochs: 25
+  max_epochs: 25
+  # gradient_clip_val: 0.5

--- a/configs/model/seq2seq_encoder/lstm.yaml
+++ b/configs/model/seq2seq_encoder/lstm.yaml
@@ -1,0 +1,5 @@
+type: lstm
+hidden_size: 256
+num_layers: 2
+bidirectional: True
+dropout: 0.1

--- a/configs/model/seq2seq_encoder/many_encoders.yaml
+++ b/configs/model/seq2seq_encoder/many_encoders.yaml
@@ -1,0 +1,6 @@
+type: sequential
+lin0:
+  type: linear
+  out_features: 2048
+act0:
+  type: tanh

--- a/configs/model/seq2seq_encoder/none.yaml
+++ b/configs/model/seq2seq_encoder/none.yaml
@@ -1,0 +1,1 @@
+type: none

--- a/configs/model/token_classification_with_seq2seq_encoder_and_crf.yaml
+++ b/configs/model/token_classification_with_seq2seq_encoder_and_crf.yaml
@@ -1,0 +1,7 @@
+defaults:
+  - seq2seq_encoder: none # have a look at the seq2seq_encoder subfolder for predefined seq2seq encoder configs
+
+_target_: pytorch_ie.models.TokenClassificationModelWithSeq2SeqEncoderAndCrf
+model_name_or_path: bert-base-uncased
+# use_crf: false  # disable the crf
+# freeze_base_model: true  # freeze the base model (transformer)

--- a/configs/taskmodule/labeled_span_extraction_by_token_classification.yaml
+++ b/configs/taskmodule/labeled_span_extraction_by_token_classification.yaml
@@ -1,0 +1,14 @@
+_target_: pytorch_ie.taskmodules.LabeledSpanExtractionByTokenClassificationTaskModule
+
+tokenizer_name_or_path: bert-base-uncased
+#span_annotation: entities
+# Long sequence handling
+#max_window: 512
+#window_overlap: 64
+# Alternative to fixed size windowing: use span annotations to partition the input
+# (this requires to add these annotations to the documents beforehand!)
+#partition_annotation: paragraphs
+combine_token_scores_method: product
+# Further parameters (also see the source code of TransformerTokenClassificationTaskModule)
+#show_statistics: true
+#include_ill_formed_predictions: false

--- a/poetry.lock
+++ b/poetry.lock
@@ -2936,6 +2936,18 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "pytorch-crf"
+version = "0.7.2"
+description = "Conditional random field in PyTorch"
+optional = false
+python-versions = ">=3.6, <4"
+groups = ["main"]
+files = [
+    {file = "pytorch-crf-0.7.2.tar.gz", hash = "sha256:e6456e22ccfc99a3d4fe1e03e996103b1b39e9830bf3c7e12e7a9077d3be866d"},
+    {file = "pytorch_crf-0.7.2-py3-none-any.whl", hash = "sha256:1b2d7d5eea3255f6e0cac09ab8b645472e76ff70d9333bc88762cf7317a4992d"},
+]
+
+[[package]]
 name = "pytorch-ie"
 version = "0.33.0"
 description = "State-of-the-art Information Extraction in PyTorch"
@@ -4640,4 +4652,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "5c6ec9ca370ff4d83a00cc2caf7d504ecc62801033edff3d5305c991d735ed8b"
+content-hash = "9e820bf7cb471e6a35b2d1337662128841aff6198fedb1949232b258dee273c3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "pie-datasets (>=0.11.0,<0.12.0)",
     "pie-core (>=0.3.1,<0.4.0)",  # to use AutoAnnotationPipeline with old models, see https://github.com/ArneBinder/pie-core/pull/95
 
+    # ---------- models ----------- #
+    "pytorch-crf (>=0.7.2,<0.8.0)",  # for CRF layer in SciArg ADUR experiment
+
     # ------- reprocessing -------- #
     "nltk (>=3.9.1,<4.0.0)",           # sentence splitter (just for drugprot.yaml experiment which dry-runs in slow tests, remove if not needed)
 


### PR DESCRIPTION
based on [sciarg_are_hps.yml](https://github.com/ArneBinder/argumentation-structure-identification/blob/main/configs/experiment/sciarg_are_hps.yaml) and [sciarg_adur_hps.yml](https://github.com/ArneBinder/argumentation-structure-identification/blob/main/configs/experiment/sciarg_adur_hps.yaml)

**IMPORTANT: This does not use all the cleanup preprocessing as defined in [sciarg_cleaned.yaml](https://github.com/ArneBinder/argumentation-structure-identification/blob/main/configs/dataset/sciarg_cleaned.yaml)! See `configs/dataset/sciarg_prepared.yml` for the actual setup.**